### PR TITLE
improv/adding_occurrence_update_due_date_bank_inter

### DIFF
--- a/src/Cnab/Retorno/Cnab400/Banco/Inter.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Inter.php
@@ -28,6 +28,7 @@ class Inter extends AbstractRetorno implements RetornoCnab400
         '03' => 'Erro',
         '06' => 'Pago',
         '07' => 'Baixado',
+        '14' => 'Alteração de data de vencimento'
     ];
 
     /**
@@ -35,9 +36,7 @@ class Inter extends AbstractRetorno implements RetornoCnab400
      *
      * @var array
      */
-    private $rejeicoes = [
-
-    ];
+    private $rejeicoes = [];
 
     /**
      * Roda antes dos metodos de processar


### PR DESCRIPTION
Adicionada nova ocorrência "'14' => 'Alteração de data de vencimento'" para o banco Inter, para a descrição da ocorrência ao realizar o processamento do retorno, não fica como "desconhecida".