### PR TITLE
improv/generate_file_unify_group_lots

### DIFF
--- a/src/Cnab/Pagamento/Cnab240/AbstractPagamento.php
+++ b/src/Cnab/Pagamento/Cnab240/AbstractPagamento.php
@@ -5,6 +5,8 @@ namespace Eduardokum\LaravelBoleto\Cnab\Pagamento\Cnab240;
 use ForceUTF8\Encoding;
 use Eduardokum\LaravelBoleto\Exception\ValidationException;
 use Eduardokum\LaravelBoleto\Cnab\Pagamento\AbstractPagamento as AbstractPagamentoGeneric;
+use Eduardokum\LaravelBoleto\Pagamento\Banco\Banco;
+use Eduardokum\LaravelBoleto\Util;
 
 abstract class AbstractPagamento extends AbstractPagamentoGeneric
 {
@@ -41,6 +43,18 @@ abstract class AbstractPagamento extends AbstractPagamentoGeneric
      * Quantidade de registros do lote.
      */
     protected $iRegistrosLote;
+
+    /**
+     * Array de lotes organizados por tipo de pagamento
+     * @var array
+     */
+    protected $lotes = [];
+
+    /**
+     * Contador de lotes
+     * @var int
+     */
+    protected $loteCounter = 0;
 
     /**
      * Função para gerar o cabeçalho do arquivo.
@@ -181,26 +195,186 @@ abstract class AbstractPagamento extends AbstractPagamentoGeneric
         }
 
         $stringRemessa = '';
-        if ($this->iRegistros < 1) {
-            throw new ValidationException('Nenhuma linha detalhe foi adicionada');
+
+        // Agrupa pagamentos por tipo
+        $this->agruparPagamentosPorTipo();
+
+        if (empty($this->lotes)) {
+            throw new ValidationException('Nenhum pagamento foi adicionado');
         }
 
+        // Header do arquivo
         $this->header();
         $stringRemessa .= $this->valida($this->getHeader()) . $this->fimLinha;
 
-        $this->headerLote();
-        $stringRemessa .= $this->valida($this->getHeaderLote()) . $this->fimLinha;
+        // Processa cada lote
+        foreach ($this->lotes as $tipoPagamento => $lote) {
+            // Header do lote
+            $this->headerLoteMulti($lote);
+            $stringRemessa .= $this->valida($this->getHeaderLote()) . $this->fimLinha;
 
-        foreach ($this->getDetalhes() as $detalhe) {
-            $stringRemessa .= $this->valida($detalhe) . $this->fimLinha;
+            // Gera segmentos diretamente para cada pagamento do lote
+            foreach ($lote['pagamentos'] as $pagamento) {
+                $this->gerarSegmentos($pagamento);
+            }
+
+            // Detalhes do lote
+            foreach ($this->getDetalhes() as $detalhe) {
+                $stringRemessa .= $this->valida($detalhe) . $this->fimLinha;
+            }
+
+            // Trailer do lote
+            $this->trailerLoteMulti($lote);
+            $stringRemessa .= $this->valida($this->getTrailerLote()) . $this->fimLinha;
+
+            // Limpa detalhes para o próximo lote
+            $this->aRegistros[self::DETALHE] = [];
+            $this->iRegistros = 0;
+            $this->iRegistrosLote = 0;
         }
 
-        $this->trailerLote();
-        $stringRemessa .= $this->valida($this->getTrailerLote()) . $this->fimLinha;
-
-        $this->trailer();
+        // Trailer do arquivo
+        $this->trailerMulti();
         $stringRemessa .= $this->valida($this->getTrailer()) . $this->fimArquivo;
 
         return Encoding::toUTF8($stringRemessa);
+    }
+
+    /**
+     * Agrupa pagamentos por tipo automaticamente
+     */
+    protected function agruparPagamentosPorTipo()
+    {
+        $this->lotes = [];
+        $this->loteCounter = 0;
+
+        foreach ($this->pagamentos as $pagamento) {
+            $tipoPagamento = $this->getTipoPagamentoDoPagamento($pagamento);
+
+            // Se não existe lote para este tipo, cria um novo
+            if (!isset($this->lotes[$tipoPagamento])) {
+                $this->lotes[$tipoPagamento] = [
+                    'numero' => ++$this->loteCounter,
+                    'tipo' => $tipoPagamento,
+                    'pagamentos' => []
+                ];
+            }
+
+            // Adiciona o pagamento ao lote
+            $this->lotes[$tipoPagamento]['pagamentos'][] = $pagamento;
+        }
+    }
+
+    /**
+     * Retorna o tipo de pagamento de um pagamento específico
+     * 
+     * @param Banco $pagamento
+     * @return string
+     */
+    protected function getTipoPagamentoDoPagamento(Banco $pagamento)
+    {
+        // Se o pagamento tem um método getTipoPagamento, usa ele
+        if (method_exists($pagamento, 'getTipoPagamento')) {
+            return $pagamento->getTipoPagamento();
+        }
+
+        // Tenta acessar a propriedade diretamente (caso seja pública)
+        if (isset($pagamento->tipoPagamento) && !empty($pagamento->tipoPagamento)) {
+            return $pagamento->tipoPagamento;
+        }
+
+        // Se o pagamento tem uma propriedade tipoPagamento, usa ela
+        if (property_exists($pagamento, 'tipoPagamento') && !empty($pagamento->tipoPagamento)) {
+            return $pagamento->tipoPagamento;
+        }
+
+        // Se não, usa o tipo padrão 'TED'
+        return 'TED';
+    }
+
+    /**
+     * Header do lote para múltiplos lotes (sobrescrever nas classes filhas)
+     *
+     * @param array $lote
+     * @return mixed
+     */
+    protected function headerLoteMulti(array $lote)
+    {
+        return $this->headerLote();
+    }
+
+    /**
+     * Trailer do lote para múltiplos lotes (sobrescrever nas classes filhas)
+     *
+     * @param array $lote
+     * @return mixed
+     */
+    protected function trailerLoteMulti(array $lote)
+    {
+        return $this->trailerLote();
+    }
+
+    /**
+     * Trailer do arquivo para múltiplos lotes (sobrescrever nas classes filhas)
+     *
+     * @return mixed
+     */
+    protected function trailerMulti()
+    {
+        return $this->trailer();
+    }
+
+    /**
+     * Retorna a quantidade de lotes
+     *
+     * @return int
+     */
+    protected function getCountLotes()
+    {
+        return count($this->lotes);
+    }
+
+    /**
+     * Retorna o valor total de um lote específico
+     *
+     * @param array $lote
+     * @return string
+     */
+    protected function getValorTotalLoteMulti(array $lote)
+    {
+        $valorTotal = 0;
+
+        // Soma todos os valores dos pagamentos no lote
+        foreach ($lote['pagamentos'] as $pagamento) {
+            if (method_exists($pagamento, 'getValor') && $pagamento->getValor() > 0)
+                $valorTotal += $pagamento->getValor();
+        }
+
+        return Util::formatCnab('9L', $valorTotal * 100, 18);
+    }
+
+    /**
+     * Processa um pagamento gerando os segmentos necessários
+     *
+     * @param Banco $pagamento
+     * @return void
+     */
+    protected function processarPagamento(Banco $pagamento)
+    {
+        // Gera os segmentos diretamente sem chamar addPagamento novamente
+        $this->gerarSegmentos($pagamento);
+    }
+
+    /**
+     * Gera os segmentos de um pagamento (sobrescrever nas classes filhas)
+     *
+     * @param Banco $pagamento
+     * @return void
+     */
+    protected function gerarSegmentos(Banco $pagamento)
+    {
+        // Método abstrato - deve ser implementado pelas classes filhas
+        // Não chama addPagamento aqui para evitar duplicação
+        throw new \Exception('Método gerarSegmentos deve ser implementado pela classe filha');
     }
 }

--- a/src/Cnab/Pagamento/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Pagamento/Cnab240/Banco/Bancoob.php
@@ -362,6 +362,8 @@ class Bancoob extends AbstractPagamento implements PagamentoRemessaContract
     public function addPagamento(PagamentoContract $pagamento)
     {
         $this->pagamentos[] = $pagamento;
+        $this->segmentoA($pagamento);
+        $this->segmentoB($pagamento);
         return $this;
     }
 
@@ -386,7 +388,7 @@ class Bancoob extends AbstractPagamento implements PagamentoRemessaContract
         $this->add(15, 15, self::TIPO_MOVIMENTO); // 06.3A Movimento Tipo - Tipo de Movimento
         $this->add(16, 17, self::CODIGO_INSTRUCAO_MOVIMENTO); // 07.3A Movimento Código - Código da Instrução p/ Movimento
         $this->add(18, 20, self::CODIGO_CAMARA_CENTRALIZADORA); // 08.3A Câmara - Código da Câmara Centralizadora
-        $this->add(21, 23, Util::formatCnab('9L', $pagamento->getBanco(), 3)); // 09.3A Banco - Código do Banco do Favorecido
+        $this->add(21, 23, Util::formatCnab('9L', $pagamento->getCodigoBanco(), 3)); // 09.3A Banco - Código do Banco do Favorecido
 
         // Favorecido - Usando dados do beneficiário (quem recebe o pagamento)
         $this->add(24, 28, Util::formatCnab('9L', $this->getAgencia(), 5)); // 10.3A Agência Código - Ag. Mantenedora da Cta do Favor.

--- a/src/Cnab/Pagamento/Cnab240/Banco/Inter.php
+++ b/src/Cnab/Pagamento/Cnab240/Banco/Inter.php
@@ -201,18 +201,6 @@ class Inter extends AbstractPagamento implements PagamentoRemessaContract
     public function addPagamento(PagamentoContract $pagamento)
     {
         $this->pagamentos[] = $pagamento;
-
-        switch ($this->getTipoPagamento()) {
-            case 'PIX': // PIX
-                $this->segmentoAPix($pagamento);
-                $this->segmentoBPix($pagamento);
-                break;
-            default: // TED
-                $this->segmentoA($pagamento);
-                $this->segmentoB($pagamento);
-                break;
-        }
-
         return $this;
     }
 
@@ -287,7 +275,7 @@ class Inter extends AbstractPagamento implements PagamentoRemessaContract
      */
     protected function getCountLotes()
     {
-        return 1; // Para pagamentos, geralmente há apenas 1 lote
+        return count($this->lotes);
     }
 
     /**
@@ -552,5 +540,151 @@ class Inter extends AbstractPagamento implements PagamentoRemessaContract
 
         $this->iRegistrosLote++;
         return $this;
+    }
+
+    /**
+     * Header do lote para múltiplos lotes
+     *
+     * @param array $lote
+     * @return Inter
+     * @throws \Exception
+     */
+    protected function headerLoteMulti(array $lote)
+    {
+        $this->iniciaHeaderLote();
+
+        $this->add(1, 3, self::BANCO); // Código do banco na compensação
+        $this->add(4, 7, Util::formatCnab('9L', $lote['numero'], 4)); // Lote de serviço (número do lote)
+        $this->add(8, 8, self::TIPO_REGISTRO_HEADER_LOTE); // Tipo de registro
+        $this->add(9, 9, self::TIPO_OPERACAO); // Tipo da operação
+        $this->add(10, 11, $this->getTipoServico()); // Tipo do serviço
+        $this->add(12, 13, $this->getFormaLancamentoPorTipo($lote['tipo'])); // Forma de lançamento (varia por tipo)
+        $this->add(14, 16, self::VERSAO_LAYOUT_LOTE); // Número da versão do layout do Lote
+        $this->add(17, 17, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(18, 18, Util::formatCnab('9L', $this->getPagador()->getTipoDocumento() == 'CPF' ? self::TIPO_DOCUMENTO_CPF : self::TIPO_DOCUMENTO_CNPJ, 1)); // Tipo de documento da empresa (CNPJ)
+        $this->add(33, 52, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(53, 57, self::AGENCIA_EMPRESA); // Agência mantenedora da conta da empresa
+        $this->add(58, 58, self::AGENCIA_DV_EMPRESA); // Dígito verificador da agência
+        $this->add(59, 70, Util::formatCnab('9L', $this->getConta(), 12)); // Número da conta corrente da empresa
+        $this->add(71, 71, $this->getContaDv()); // Dígito verificador da conta
+        $this->add(72, 72, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(73, 102, Util::formatCnab('X', $this->getPagador()->getNome(), 30)); // Nome da empresa
+        $this->add(103, 142, self::CAMPO_BRANCO); // Informação genérica opcional
+        $this->add(143, 172, Util::formatCnab('X', $this->getPagador()->getEndereco(), 30)); // Nome da Rua, Av, Pça, Etc.
+        $this->add(173, 177, self::CAMPO_BRANCO); // Número do local da empresa
+        $this->add(178, 192, self::CAMPO_BRANCO); // Casa, Apto, Sala, Etc.
+        $this->add(193, 212, Util::formatCnab('X', $this->getPagador()->getCidade(), 20)); // Nome da cidade da empresa
+
+        $cep = Util::formatCnab('9L', $this->getPagador()->getCep(), 8);
+
+        $this->add(213, 217, substr($cep, 0, 5)); // CEP da empresa
+        $this->add(218, 220, substr($cep, 5, 3)); // Complemento do CEP
+        $this->add(221, 222, $this->getPagador()->getUf()); // Sigla do estado da empresa
+        $this->add(223, 230, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(231, 240, self::CAMPO_BRANCO); // Códigos das ocorrências para retorno
+
+        return $this;
+    }
+
+    /**
+     * Trailer do lote para múltiplos lotes
+     *
+     * @param array $lote
+     * @return Inter
+     * @throws \Exception
+     */
+    protected function trailerLoteMulti(array $lote)
+    {
+        $this->iniciaTrailerLote();
+
+        $this->add(1, 3, self::BANCO); // Código do banco na compensação
+        $this->add(4, 7, Util::formatCnab('9L', $lote['numero'], 4)); // Lote de serviço (Número do lote)
+        $this->add(8, 8, self::TIPO_REGISTRO_TRAILER_LOTE); // Tipo de registro
+        $this->add(9, 17, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(18, 23, Util::formatCnab('9L', $this->getCountRegistrosLote(), 6)); // Quantidade de lotes no arquivo
+        $this->add(24, 41, Util::formatCnab('9L', $this->getValorTotalLoteMulti($lote), 18)); // Somatória dos valores
+        $this->add(42, 59, Util::formatCnab('9L', self::QUANTIDADE_MOEDA, 18)); // Somatória de quantidade de moedas
+        $this->add(60, 65, self::CAMPO_BRANCO); // Número aviso de débito
+        $this->add(66, 230, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(231, 240, self::CAMPO_BRANCO); // Códigos das ocorrências para retorno
+
+        return $this;
+    }
+
+    /**
+     * Trailer do arquivo para múltiplos lotes
+     *
+     * @return Inter
+     * @throws \Exception
+     */
+    protected function trailerMulti()
+    {
+        $this->iniciaTrailer();
+
+        $this->add(1, 3, self::BANCO); // Código do banco na compensação
+        $this->add(4, 7, self::LOTE_SERVICO_TRAILER); // Lote de serviço
+        $this->add(8, 8, self::TIPO_REGISTRO_TRAILER); // Tipo de registro
+        $this->add(9, 17, self::CAMPO_BRANCO); // Campo em branco
+        $this->add(18, 23, Util::formatCnab('9L', $this->getCountLotes(), 6)); // Quantidade de lotes do arquivo
+        $this->add(24, 29, Util::formatCnab('9L', $this->getCountMulti(), 6)); // Quantidade de registros do arquivo
+        $this->add(30, 240, self::CAMPO_BRANCO); // Campo em branco
+
+        return $this;
+    }
+
+    /**
+     * Retorna a forma de lançamento baseada no tipo de pagamento específico
+     *
+     * @param string $tipoPagamento
+     * @return string
+     */
+    protected function getFormaLancamentoPorTipo($tipoPagamento)
+    {
+        switch ($tipoPagamento) {
+            case 'TED':
+                return '03'; // TED
+            case 'PIX':
+                return '45'; // Transferência via PIX
+            default:
+                return '03'; // Padrão TED
+        }
+    }
+
+    /**
+     * Retorna a quantidade total de registros para múltiplos lotes
+     *
+     * @return int
+     */
+    protected function getCountMulti()
+    {
+        $totalRegistros = 0;
+        foreach ($this->lotes as $lote) {
+            $totalRegistros += count($lote['pagamentos']) * 2; // Segmento A + B para cada pagamento
+            $totalRegistros += 2; // Header + Trailer do lote
+        }
+        $totalRegistros += 2; // Header + Trailer do arquivo
+        return $totalRegistros;
+    }
+
+    /**
+     * Gera os segmentos de um pagamento baseado no tipo
+     *
+     * @param \Eduardokum\LaravelBoleto\Pagamento\Banco\Banco $pagamento
+     * @return void
+     */
+    protected function gerarSegmentos(\Eduardokum\LaravelBoleto\Pagamento\Banco\Banco $pagamento)
+    {
+        $tipoPagamento = $this->getTipoPagamentoDoPagamento($pagamento);
+
+        switch ($tipoPagamento) {
+            case 'PIX':
+                $this->segmentoAPix($pagamento);
+                $this->segmentoBPix($pagamento);
+                break;
+            default: // TED
+                $this->segmentoA($pagamento);
+                $this->segmentoB($pagamento);
+                break;
+        }
     }
 }

--- a/src/Pagamento/AbstractPagamento.php
+++ b/src/Pagamento/AbstractPagamento.php
@@ -971,12 +971,9 @@ abstract class AbstractPagamento implements PagamentoContract
      */
     public function toArray()
     {
-        $nosso_numero = $nosso_numero_boleto = $linha_digitavel = $codigo_barras = null;
+        $nosso_numero = null;
         try {
             $nosso_numero = $this->getNossoNumero();
-            $nosso_numero_boleto = $this->getNossoNumeroBoleto();
-            $linha_digitavel = $this->getLinhaDigitavel();
-            $codigo_barras = $this->getCodigoBarras();
         } catch (Exception $e) {
         }
 


### PR DESCRIPTION
Elaborado maneira de agrupar lançamentos por tipo de pagamento, para gerar o arquivo de remessa com vários lotes, unificando o arquivo