### PR TITLE
feat/viacredi_bank_integration

### DIFF
--- a/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
@@ -31,8 +31,13 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
     const VERSAO_LAYOUT_LOTE = '045'; // Header de lote pos 14-16 (manual seção 5.1.2)
 
     const LOTE_SERVICO_HEADER_ARQUIVO = '0000';
-    const LOTE_SERVICO_HEADER_LOTE = '0001';
+    const LOTE_SERVICO_HEADER_LOTE = '0001'; // legado — multilote usa $this->loteAtualNumero
     const LOTE_SERVICO_TRAILER = '9999';
+
+    // Tipos canônicos usados pelo agrupador (AbstractPagamento::agruparPagamentosPorTipo)
+    // para separar boletos da própria Ailos (forma 30) dos demais (forma 31).
+    const TIPO_PAGAMENTO_BOLETO_AILOS  = 'BOLETO_AILOS';
+    const TIPO_PAGAMENTO_BOLETO_OUTROS = 'BOLETO_OUTROS';
 
     const TIPO_REGISTRO_HEADER_ARQUIVO = '0';
     const TIPO_REGISTRO_HEADER_LOTE = '1';
@@ -64,6 +69,20 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
      * (não segmentos): J e J-52 do mesmo título compartilham o mesmo número.
      */
     protected $iSequencialPagamento = 0;
+
+    /**
+     * Número do lote atualmente sendo gravado (pos 4-7 dos registros do lote).
+     * Atualizado por headerLoteMulti() e reusado por segmentoJ/J-52/trailer
+     * para evitar hardcode de "0001" em arquivos multilote.
+     */
+    protected $loteAtualNumero = 1;
+
+    /**
+     * Lista de pagamentos do lote atual (subset de $this->pagamentos).
+     * Definida por headerLoteMulti/trailerLoteMulti e consultada por
+     * getFormaLancamento() e somatórios de trailer para isolar o lote.
+     */
+    protected $loteAtualPagamentos = null;
 
     protected $codigoBanco = self::BANCO;
     protected $carteiras = [];
@@ -101,20 +120,50 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
      * Resolve a forma de lançamento conforme o boleto a pagar:
      * - 30 quando é boleto da própria Ailos (banco 085 no código de barras)
      * - 31 quando é boleto de outra instituição financeira
+     *
+     * Em multilote, $loteAtualPagamentos restringe a inspeção ao lote em
+     * gravação — evita retornar a forma de outro lote.
      */
     public function getFormaLancamento()
     {
-        $primeiroPagamento = $this->pagamentos[0] ?? null;
+        $pagamentos = $this->loteAtualPagamentos ?? $this->pagamentos;
+        $primeiroPagamento = $pagamentos[0] ?? null;
 
         if ($primeiroPagamento && method_exists($primeiroPagamento, 'getCodigoBarras')) {
-            $bancoFavorecido = substr(Util::onlyNumbers($primeiroPagamento->getCodigoBarras()), 0, 3);
-
-            return $bancoFavorecido === self::BANCO
+            return $this->ehBoletoAilos($primeiroPagamento)
                 ? self::FORMA_LANCAMENTO_BOLETO_AILOS
                 : self::FORMA_LANCAMENTO_BOLETO_OUTROS;
         }
 
         return self::FORMA_LANCAMENTO_BOLETO_OUTROS;
+    }
+
+    /**
+     * Classifica um pagamento como boleto Ailos (banco 085 nas 3 primeiras
+     * posições do código de barras) ou de outro banco. Usado pelo agrupador
+     * de lotes e pela escolha de forma de lançamento.
+     */
+    protected function ehBoletoAilos($pagamento): bool
+    {
+        if (!method_exists($pagamento, 'getCodigoBarras')) {
+            return false;
+        }
+
+        $bancoFavorecido = substr(Util::onlyNumbers($pagamento->getCodigoBarras() ?? ''), 0, 3);
+
+        return $bancoFavorecido === self::BANCO;
+    }
+
+    /**
+     * Sobrescreve o agrupador padrão para que boletos Ailos (forma 30) e
+     * boletos de outros bancos (forma 31) caiam em lotes separados — manual
+     * 5.1 exige um único tipo de serviço/forma por lote.
+     */
+    protected function getTipoPagamentoDoPagamento(\Eduardokum\LaravelBoleto\Pagamento\Banco\Banco $pagamento)
+    {
+        return $this->ehBoletoAilos($pagamento)
+            ? self::TIPO_PAGAMENTO_BOLETO_AILOS
+            : self::TIPO_PAGAMENTO_BOLETO_OUTROS;
     }
 
     /**
@@ -140,7 +189,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $this->add(59, 70, Util::formatCnab('9L', $this->getConta(), 12));                                  // 059-070: Conta
         $this->add(71, 71, Util::formatCnab('X', $this->getContaDv() ?? '', 1));                            // 071-071: DV Conta
         $this->add(72, 72, self::CAMPO_BRANCO);                                                             // 072-072: DV Ag/Conta (branco)
-        $this->add(73, 102, Util::formatCnab('X', $this->getPagador()->getNome(), 30));                     // 073-102: Nome da Empresa
+        $this->add(73, 102, Util::formatCnab('X', Util::normalizeChars($this->getPagador()->getNome()), 30)); // 073-102: Nome da Empresa
         $this->add(103, 132, Util::formatCnab('X', self::NOME_BANCO, 30));                                  // 103-132: Nome do Banco
         $this->add(133, 142, self::CAMPO_BRANCO);                                                           // 133-142: Brancos
         $this->add(143, 143, self::CODIGO_REMESSA);                                                         // 143-143: Código Remessa/Retorno
@@ -169,7 +218,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
             : self::TIPO_DOCUMENTO_CNPJ;
 
         $this->add(1, 3, self::BANCO);                                                                      // 001-003: Código do Banco (085)
-        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Código do Lote (0001)
+        $this->add(4, 7, Util::formatCnab('9L', $this->loteAtualNumero, 4));                                // 004-007: Código do Lote (NOTA 3)
         $this->add(8, 8, self::TIPO_REGISTRO_HEADER_LOTE);                                                  // 008-008: Tipo de Registro (1)
         $this->add(9, 9, self::TIPO_OPERACAO);                                                              // 009-009: Tipo de Operação (C)
         $this->add(10, 11, $this->getTipoServico());                                                        // 010-011: Tipo de Serviço
@@ -184,12 +233,12 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $this->add(59, 70, Util::formatCnab('9L', $this->getConta(), 12));                                  // 059-070: Conta
         $this->add(71, 71, Util::formatCnab('X', $this->getContaDv() ?? '', 1));                            // 071-071: DV Conta
         $this->add(72, 72, self::CAMPO_BRANCO);                                                             // 072-072: DV Ag/Conta
-        $this->add(73, 102, Util::formatCnab('X', $this->getPagador()->getNome(), 30));                     // 073-102: Nome da Empresa
+        $this->add(73, 102, Util::formatCnab('X', Util::normalizeChars($this->getPagador()->getNome()), 30)); // 073-102: Nome da Empresa
         $this->add(103, 142, self::CAMPO_BRANCO);                                                           // 103-142: Mensagem
-        $this->add(143, 172, Util::formatCnab('X', $this->getPagador()->getEndereco() ?? '', 30));          // 143-172: Endereço
+        $this->add(143, 172, Util::formatCnab('X', Util::normalizeChars($this->getPagador()->getEndereco() ?? ''), 30)); // 143-172: Endereço
         $this->add(173, 177, self::CAMPO_BRANCO);                                                           // 173-177: Número do Local
         $this->add(178, 192, self::CAMPO_BRANCO);                                                           // 178-192: Casa, Apto
-        $this->add(193, 212, Util::formatCnab('X', $this->getPagador()->getCidade() ?? '', 20));            // 193-212: Cidade
+        $this->add(193, 212, Util::formatCnab('X', Util::normalizeChars($this->getPagador()->getCidade() ?? ''), 20)); // 193-212: Cidade
         $cep = Util::formatCnab('9L', $this->getPagador()->getCep() ?? '', 8);
         $this->add(213, 217, substr($cep, 0, 5));                                                           // 213-217: CEP
         $this->add(218, 220, substr($cep, 5, 3));                                                           // 218-220: Complemento CEP
@@ -227,7 +276,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $codigoBarras = Util::onlyNumbers($pagamento->getCodigoBarras() ?? '');
 
         $this->add(1, 3, self::BANCO);                                                                      // 001-003: Banco
-        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Lote
+        $this->add(4, 7, Util::formatCnab('9L', $this->loteAtualNumero, 4));                                // 004-007: Lote
         $this->add(8, 8, self::TIPO_REGISTRO_DETALHE);                                                      // 008-008: Tipo Registro (3)
         $this->add(9, 13, Util::formatCnab('9L', $this->iSequencialPagamento, 5));                          // 009-013: Nº Sequencial Registro Lote
         $this->add(14, 14, self::CODIGO_SEGMENTO_J);                                                        // 014-014: Segmento (J)
@@ -242,7 +291,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $this->add(37, 61, substr($codigoBarras, 19, 25)); // Campo livre
 
         // Nome do beneficiário (cedente do boleto)
-        $this->add(62, 91, Util::formatCnab('X', $pagamento->getBeneficiario()->getNome(), 30));
+        $this->add(62, 91, Util::formatCnab('X', Util::normalizeChars($pagamento->getBeneficiario()->getNome()), 30));
 
         // Data de vencimento nominal
         $dataVencimento = $pagamento->getDataVencimento()
@@ -274,8 +323,9 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
 
         $this->add(168, 182, Util::formatCnab('9', '0', 15));                                               // 168-182: Zeros
         $this->add(183, 202, Util::formatCnab('X', $pagamento->getNumeroControle() ?? '', 20));             // 183-202: Seu Número (nº doc atribuído pela empresa)
-        $this->add(203, 215, self::CAMPO_BRANCO);                                                           // 203-215: Brancos
-        $this->add(216, 230, self::CAMPO_BRANCO);                                                           // 216-230: Nosso Número (preenchido no retorno)
+        $this->add(203, 222, self::CAMPO_BRANCO);                                                           // 203-222: Nosso Número (preenchido no retorno - 20 alfa)
+        $this->add(223, 224, Util::formatCnab('9', '09', 2));                                               // 223-224: Código da Moeda (09 = Real, G065)
+        $this->add(225, 230, self::CAMPO_BRANCO);                                                           // 225-230: CNAB
         $this->add(231, 240, self::CAMPO_BRANCO);                                                           // 231-240: Ocorrências (preenchido no retorno)
 
         return $this;
@@ -304,7 +354,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
             : null;
 
         $this->add(1, 3, self::BANCO);                                                                      // 001-003: Banco
-        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Lote
+        $this->add(4, 7, Util::formatCnab('9L', $this->loteAtualNumero, 4));                                // 004-007: Lote
         $this->add(8, 8, self::TIPO_REGISTRO_DETALHE);                                                      // 008-008: Tipo Registro (3)
         $this->add(9, 13, Util::formatCnab('9L', $this->iSequencialPagamento, 5));                          // 009-013: Mesmo seq do J
         $this->add(14, 14, self::CODIGO_SEGMENTO_J);                                                        // 014-014: Segmento (J)
@@ -313,11 +363,11 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
 
         $this->add(20, 20, $tipoInscSacado);                                                                // 020-020: Tipo Insc Sacado
         $this->add(21, 35, Util::formatCnab('9L', $sacado->getDocumento(), 15));                            // 021-035: Nº Inscrição Sacado
-        $this->add(36, 75, Util::formatCnab('X', $sacado->getNome(), 40));                                  // 036-075: Nome Sacado
+        $this->add(36, 75, Util::formatCnab('X', Util::normalizeChars($sacado->getNome()), 40));            // 036-075: Nome Sacado
 
         $this->add(76, 76, $tipoInscCedente);                                                               // 076-076: Tipo Insc Cedente
         $this->add(77, 91, Util::formatCnab('9L', $cedente->getDocumento(), 15));                           // 077-091: Nº Inscrição Cedente
-        $this->add(92, 131, Util::formatCnab('X', $cedente->getNome(), 40));                                // 092-131: Nome Cedente
+        $this->add(92, 131, Util::formatCnab('X', Util::normalizeChars($cedente->getNome()), 40));          // 092-131: Nome Cedente
 
         if ($sacadorAvalista !== null) {
             $tipoInscSacador = $sacadorAvalista->getTipoDocumento() == 'CPF'
@@ -325,7 +375,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
                 : self::TIPO_DOCUMENTO_CNPJ;
             $this->add(132, 132, $tipoInscSacador);
             $this->add(133, 147, Util::formatCnab('9L', $sacadorAvalista->getDocumento(), 15));
-            $this->add(148, 187, Util::formatCnab('X', $sacadorAvalista->getNome(), 40));
+            $this->add(148, 187, Util::formatCnab('X', Util::normalizeChars($sacadorAvalista->getNome()), 40));
         } else {
             $this->add(132, 132, '0');
             $this->add(133, 147, Util::formatCnab('9', '0', 15));
@@ -345,7 +395,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $this->iniciaTrailerLote();
 
         $this->add(1, 3, self::BANCO);
-        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);
+        $this->add(4, 7, Util::formatCnab('9L', $this->loteAtualNumero, 4));
         $this->add(8, 8, self::TIPO_REGISTRO_TRAILER_LOTE);
         $this->add(9, 17, self::CAMPO_BRANCO);
         $this->add(18, 23, Util::formatCnab('9L', $this->getCountRegistrosLote(), 6));
@@ -358,28 +408,65 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
     }
 
     /**
-     * Trailer do arquivo.
+     * Trailer do arquivo. Soma lotes e registros corretamente em multilote.
      */
     protected function trailer()
     {
         $this->iniciaTrailer();
 
+        $totalLotes = empty($this->lotes) ? 1 : $this->getCountLotes();
+        $totalRegistros = empty($this->lotes) ? $this->getCount() : $this->getCountMulti();
+
         $this->add(1, 3, self::BANCO);
         $this->add(4, 7, self::LOTE_SERVICO_TRAILER);
         $this->add(8, 8, self::TIPO_REGISTRO_TRAILER_ARQUIVO);
         $this->add(9, 17, self::CAMPO_BRANCO);
-        $this->add(18, 23, Util::formatCnab('9L', 1, 6));                                                   // Sempre 1 lote
-        $this->add(24, 29, Util::formatCnab('9L', $this->getCount(), 6));                                   // Total registros do arquivo
+        $this->add(18, 23, Util::formatCnab('9L', $totalLotes, 6));                                         // Quantidade de lotes do arquivo
+        $this->add(24, 29, Util::formatCnab('9L', $totalRegistros, 6));                                     // Total de registros do arquivo
         $this->add(30, 35, Util::formatCnab('9L', 0, 6));
         $this->add(36, 240, self::CAMPO_BRANCO);
 
         return $this;
     }
 
+    /**
+     * Header do lote para multilote: memoriza o número e a fatia de pagamentos
+     * deste lote e delega para headerLote(), que já usa essas referências.
+     */
+    protected function headerLoteMulti(array $lote)
+    {
+        $this->loteAtualNumero = (int) $lote['numero'];
+        $this->loteAtualPagamentos = $lote['pagamentos'];
+
+        return $this->headerLote();
+    }
+
+    /**
+     * Trailer do lote para multilote: idem headerLoteMulti.
+     */
+    protected function trailerLoteMulti(array $lote)
+    {
+        $this->loteAtualNumero = (int) $lote['numero'];
+        $this->loteAtualPagamentos = $lote['pagamentos'];
+
+        return $this->trailerLote();
+    }
+
+    /**
+     * Trailer do arquivo para multilote (chamado por AbstractPagamento::gerar).
+     */
+    protected function trailerMulti()
+    {
+        return $this->trailer();
+    }
+
     protected function getCountDetalhes()
     {
-        // Cada pagamento gera 2 segmentos (J + J-52)
-        return count($this->pagamentos) * 2;
+        // Cada pagamento gera 2 segmentos (J + J-52). Em multilote, usa só os
+        // pagamentos do lote atual; fora dele, todos os pagamentos.
+        $alvo = $this->loteAtualPagamentos ?? $this->pagamentos;
+
+        return count($alvo) * 2;
     }
 
     protected function getCountRegistrosLote()
@@ -389,12 +476,48 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
 
     protected function getValorTotalLote()
     {
+        $alvo = $this->loteAtualPagamentos ?? $this->pagamentos;
         $valorTotal = 0;
-        foreach ($this->pagamentos as $pagamento) {
+
+        foreach ($alvo as $pagamento) {
             if (method_exists($pagamento, 'getValor') && $pagamento->getValor() > 0) {
                 $valorTotal += $pagamento->getValor();
             }
         }
+
+        return Util::formatCnab('9L', $valorTotal * 100, 18);
+    }
+
+    /**
+     * Total de registros do arquivo considerando todos os lotes.
+     */
+    protected function getCountMulti()
+    {
+        $total = 0;
+
+        foreach ($this->lotes as $lote) {
+            $total += count($lote['pagamentos']) * 2; // J + J-52
+            $total += 2;                              // header e trailer do lote
+        }
+
+        $total += 2; // header e trailer do arquivo
+
+        return $total;
+    }
+
+    /**
+     * Total monetário de um lote específico (usado pelos trailers multilote).
+     */
+    protected function getValorTotalLoteMulti(array $lote)
+    {
+        $valorTotal = 0;
+
+        foreach ($lote['pagamentos'] as $pagamento) {
+            if (method_exists($pagamento, 'getValor') && $pagamento->getValor() > 0) {
+                $valorTotal += $pagamento->getValor();
+            }
+        }
+
         return Util::formatCnab('9L', $valorTotal * 100, 18);
     }
 

--- a/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
@@ -1,0 +1,413 @@
+<?php
+
+namespace Eduardokum\LaravelBoleto\Cnab\Pagamento\Cnab240\Banco;
+
+use Eduardokum\LaravelBoleto\Cnab\Pagamento\Cnab240\AbstractPagamento;
+use Eduardokum\LaravelBoleto\Contracts\Cnab\Pagamento as PagamentoRemessaContract;
+use Eduardokum\LaravelBoleto\Contracts\Pagamento\Pagamento as PagamentoContract;
+use Eduardokum\LaravelBoleto\Util;
+
+/**
+ * Class Ailos
+ *
+ * Remessa CNAB 240 do Sistema Ailos (banco 085) para PAGAMENTO DE TÍTULOS DE
+ * COBRANÇA (boletos da própria cooperativa ou de outras instituições). Manual
+ * "Pagamento por Arquivo - Layout 240 Posições" (versão 10, mai/2025).
+ *
+ * Usa segmentos J (obrigatório) + J-52 (obrigatório) — manual seção 5.1.3 e 5.1.4.
+ * Segmento J-53 (opcional, agregador eletrônico) não está implementado.
+ *
+ * Valores não suportados pela Ailos neste manual: PIX, TED/DOC, transferência
+ * entre contas. Se essas modalidades forem necessárias, exigem manual adicional
+ * fornecido pela cooperativa.
+ *
+ * @package Eduardokum\LaravelBoleto\Cnab\Pagamento\Cnab240\Banco
+ */
+class Ailos extends AbstractPagamento implements PagamentoRemessaContract
+{
+    const BANCO = '085';
+    const NOME_BANCO = 'AILOS';
+    const VERSAO_LAYOUT = '088';      // Header de arquivo pos 164-166 (manual seção 5.1.1)
+    const VERSAO_LAYOUT_LOTE = '045'; // Header de lote pos 14-16 (manual seção 5.1.2)
+
+    const LOTE_SERVICO_HEADER_ARQUIVO = '0000';
+    const LOTE_SERVICO_HEADER_LOTE = '0001';
+    const LOTE_SERVICO_TRAILER = '9999';
+
+    const TIPO_REGISTRO_HEADER_ARQUIVO = '0';
+    const TIPO_REGISTRO_HEADER_LOTE = '1';
+    const TIPO_REGISTRO_DETALHE = '3';
+    const TIPO_REGISTRO_TRAILER_LOTE = '5';
+    const TIPO_REGISTRO_TRAILER_ARQUIVO = '9';
+
+    const TIPO_OPERACAO = 'C'; // Crédito
+    const CODIGO_REMESSA = '1'; // 1=Remessa, 2=Retorno
+
+    const TIPO_DOCUMENTO_CPF = '1';
+    const TIPO_DOCUMENTO_CNPJ = '2';
+
+    const CODIGO_SEGMENTO_J = 'J';
+    const CODIGO_REGISTRO_OPCIONAL_J52 = '52';
+
+    // Tipo de serviço (G025) — pagamento a fornecedores
+    const TIPO_SERVICO_FORNECEDOR = '20';
+
+    // Forma de lançamento (G029) — manual seção 5.1.2
+    const FORMA_LANCAMENTO_BOLETO_AILOS  = '30'; // Pagamento de título de cobrança Ailos
+    const FORMA_LANCAMENTO_BOLETO_OUTROS = '31'; // Pagamento de título de outros bancos
+
+    const CAMPO_BRANCO = '';
+    const DENSIDADE_GRAVACAO = '01600';
+
+    /**
+     * Sequencial do pagamento dentro do lote (Febraban G038). Conta pagamentos
+     * (não segmentos): J e J-52 do mesmo título compartilham o mesmo número.
+     */
+    protected $iSequencialPagamento = 0;
+
+    protected $codigoBanco = self::BANCO;
+    protected $carteiras = [];
+
+    protected $fimLinha = "\r\n";
+    protected $fimArquivo = "\r\n";
+
+    public function __construct(array $params = [])
+    {
+        parent::__construct($params);
+        $this->codigoBanco = self::BANCO;
+    }
+
+    public function getCodigoBanco()
+    {
+        return self::BANCO;
+    }
+
+    protected function getNomeBanco()
+    {
+        return self::NOME_BANCO;
+    }
+
+    protected function getVersaoLayout()
+    {
+        return self::VERSAO_LAYOUT;
+    }
+
+    public function getTipoServico()
+    {
+        return $this->tipoServico ?? self::TIPO_SERVICO_FORNECEDOR;
+    }
+
+    /**
+     * Resolve a forma de lançamento conforme o boleto a pagar:
+     * - 30 quando é boleto da própria Ailos (banco 085 no código de barras)
+     * - 31 quando é boleto de outra instituição financeira
+     */
+    public function getFormaLancamento()
+    {
+        $primeiroPagamento = $this->pagamentos[0] ?? null;
+
+        if ($primeiroPagamento && method_exists($primeiroPagamento, 'getCodigoBarras')) {
+            $bancoFavorecido = substr(Util::onlyNumbers($primeiroPagamento->getCodigoBarras()), 0, 3);
+
+            return $bancoFavorecido === self::BANCO
+                ? self::FORMA_LANCAMENTO_BOLETO_AILOS
+                : self::FORMA_LANCAMENTO_BOLETO_OUTROS;
+        }
+
+        return self::FORMA_LANCAMENTO_BOLETO_OUTROS;
+    }
+
+    /**
+     * Header do arquivo (manual seção 5.1.1).
+     */
+    protected function header()
+    {
+        $this->iniciaHeader();
+
+        $tipoInsc = $this->getPagador()->getTipoDocumento() == 'CPF'
+            ? self::TIPO_DOCUMENTO_CPF
+            : self::TIPO_DOCUMENTO_CNPJ;
+
+        $this->add(1, 3, self::BANCO);                                                                      // 001-003: Código do Banco (085)
+        $this->add(4, 7, self::LOTE_SERVICO_HEADER_ARQUIVO);                                                // 004-007: Lote de Serviço (0000)
+        $this->add(8, 8, self::TIPO_REGISTRO_HEADER_ARQUIVO);                                               // 008-008: Tipo de Registro (0)
+        $this->add(9, 17, self::CAMPO_BRANCO);                                                              // 009-017: Brancos (Uso FEBRABAN)
+        $this->add(18, 18, $tipoInsc);                                                                      // 018-018: Tipo de Inscrição da Empresa
+        $this->add(19, 32, Util::formatCnab('9L', $this->getPagador()->getDocumento(), 14));                // 019-032: Nº Inscrição da Empresa
+        $this->add(33, 52, Util::formatCnab('X', $this->getConvenio() ?? '', 20));                          // 033-052: Código do Convênio
+        $this->add(53, 57, Util::formatCnab('9L', $this->getAgencia(), 5));                                 // 053-057: Agência
+        $this->add(58, 58, Util::formatCnab('X', $this->getAgenciaDv() ?? '', 1));                          // 058-058: DV Agência
+        $this->add(59, 70, Util::formatCnab('9L', $this->getConta(), 12));                                  // 059-070: Conta
+        $this->add(71, 71, Util::formatCnab('X', $this->getContaDv() ?? '', 1));                            // 071-071: DV Conta
+        $this->add(72, 72, self::CAMPO_BRANCO);                                                             // 072-072: DV Ag/Conta (branco)
+        $this->add(73, 102, Util::formatCnab('X', $this->getPagador()->getNome(), 30));                     // 073-102: Nome da Empresa
+        $this->add(103, 132, Util::formatCnab('X', self::NOME_BANCO, 30));                                  // 103-132: Nome do Banco
+        $this->add(133, 142, self::CAMPO_BRANCO);                                                           // 133-142: Brancos
+        $this->add(143, 143, self::CODIGO_REMESSA);                                                         // 143-143: Código Remessa/Retorno
+        $this->add(144, 151, $this->getDataRemessa('dmY'));                                                 // 144-151: Data Geração
+        $this->add(152, 157, $this->getDataRemessa('His'));                                                 // 152-157: Hora Geração
+        $this->add(158, 163, Util::formatCnab('9L', $this->getIdremessa(), 6));                             // 158-163: Nº Sequencial Arquivo
+        $this->add(164, 166, self::VERSAO_LAYOUT);                                                          // 164-166: Versão Layout Arquivo (088)
+        $this->add(167, 171, self::DENSIDADE_GRAVACAO);                                                     // 167-171: Densidade Gravação
+        $this->add(172, 191, self::CAMPO_BRANCO);                                                           // 172-191: Reservado Banco
+        $this->add(192, 211, self::CAMPO_BRANCO);                                                           // 192-211: Reservado Empresa
+        $this->add(212, 240, self::CAMPO_BRANCO);                                                           // 212-240: Brancos
+
+        return $this;
+    }
+
+    /**
+     * Header do lote (manual seção 5.1.2).
+     */
+    protected function headerLote()
+    {
+        $this->iniciaHeaderLote();
+        $this->iSequencialPagamento = 0;
+
+        $tipoInsc = $this->getPagador()->getTipoDocumento() == 'CPF'
+            ? self::TIPO_DOCUMENTO_CPF
+            : self::TIPO_DOCUMENTO_CNPJ;
+
+        $this->add(1, 3, self::BANCO);                                                                      // 001-003: Código do Banco (085)
+        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Código do Lote (0001)
+        $this->add(8, 8, self::TIPO_REGISTRO_HEADER_LOTE);                                                  // 008-008: Tipo de Registro (1)
+        $this->add(9, 9, self::TIPO_OPERACAO);                                                              // 009-009: Tipo de Operação (C)
+        $this->add(10, 11, $this->getTipoServico());                                                        // 010-011: Tipo de Serviço
+        $this->add(12, 13, $this->getFormaLancamento());                                                    // 012-013: Forma de Lançamento (30 ou 31)
+        $this->add(14, 16, self::VERSAO_LAYOUT_LOTE);                                                       // 014-016: Versão Layout Lote (045)
+        $this->add(17, 17, self::CAMPO_BRANCO);                                                             // 017-017: Brancos
+        $this->add(18, 18, $tipoInsc);                                                                      // 018-018: Tipo Inscrição Empresa
+        $this->add(19, 32, Util::formatCnab('9L', $this->getPagador()->getDocumento(), 14));                // 019-032: Nº Inscrição Empresa
+        $this->add(33, 52, Util::formatCnab('X', $this->getConvenio() ?? '', 20));                          // 033-052: Convênio
+        $this->add(53, 57, Util::formatCnab('9L', $this->getAgencia(), 5));                                 // 053-057: Agência
+        $this->add(58, 58, Util::formatCnab('X', $this->getAgenciaDv() ?? '', 1));                          // 058-058: DV Agência
+        $this->add(59, 70, Util::formatCnab('9L', $this->getConta(), 12));                                  // 059-070: Conta
+        $this->add(71, 71, Util::formatCnab('X', $this->getContaDv() ?? '', 1));                            // 071-071: DV Conta
+        $this->add(72, 72, self::CAMPO_BRANCO);                                                             // 072-072: DV Ag/Conta
+        $this->add(73, 102, Util::formatCnab('X', $this->getPagador()->getNome(), 30));                     // 073-102: Nome da Empresa
+        $this->add(103, 142, self::CAMPO_BRANCO);                                                           // 103-142: Mensagem
+        $this->add(143, 172, Util::formatCnab('X', $this->getPagador()->getEndereco() ?? '', 30));          // 143-172: Endereço
+        $this->add(173, 177, self::CAMPO_BRANCO);                                                           // 173-177: Número do Local
+        $this->add(178, 192, self::CAMPO_BRANCO);                                                           // 178-192: Casa, Apto
+        $this->add(193, 212, Util::formatCnab('X', $this->getPagador()->getCidade() ?? '', 20));            // 193-212: Cidade
+        $cep = Util::formatCnab('9L', $this->getPagador()->getCep() ?? '', 8);
+        $this->add(213, 217, substr($cep, 0, 5));                                                           // 213-217: CEP
+        $this->add(218, 220, substr($cep, 5, 3));                                                           // 218-220: Complemento CEP
+        $this->add(221, 222, Util::formatCnab('X', $this->getPagador()->getUf() ?? '', 2));                 // 221-222: UF
+        $this->add(223, 230, self::CAMPO_BRANCO);                                                           // 223-230: Brancos
+        $this->add(231, 240, self::CAMPO_BRANCO);                                                           // 231-240: Ocorrências (uso retorno)
+
+        return $this;
+    }
+
+    public function addPagamento(PagamentoContract $pagamento)
+    {
+        $this->pagamentos[] = $pagamento;
+        return $this;
+    }
+
+    /**
+     * Para cada pagamento, gera o par de segmentos J + J-52 obrigatórios.
+     */
+    protected function gerarSegmentos(\Eduardokum\LaravelBoleto\Pagamento\Banco\Banco $pagamento)
+    {
+        $this->segmentoJ($pagamento);
+        $this->segmentoJ52($pagamento);
+    }
+
+    /**
+     * Segmento J — Pagamento de título de cobrança (manual seção 5.1.3).
+     * Posições 018-061 contêm a decomposição do código de barras do boleto.
+     */
+    public function segmentoJ($pagamento)
+    {
+        $this->iniciaDetalhe();
+        $this->iSequencialPagamento++;
+
+        $codigoBarras = Util::onlyNumbers($pagamento->getCodigoBarras() ?? '');
+
+        $this->add(1, 3, self::BANCO);                                                                      // 001-003: Banco
+        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Lote
+        $this->add(8, 8, self::TIPO_REGISTRO_DETALHE);                                                      // 008-008: Tipo Registro (3)
+        $this->add(9, 13, Util::formatCnab('9L', $this->iSequencialPagamento, 5));                          // 009-013: Nº Sequencial Registro Lote
+        $this->add(14, 14, self::CODIGO_SEGMENTO_J);                                                        // 014-014: Segmento (J)
+        $this->add(15, 17, Util::formatCnab('9L', '0', 3));                                                 // 015-017: Tipo de Movimento
+
+        // 018-061: Código de barras decomposto
+        $this->add(18, 20, substr($codigoBarras, 0, 3));   // Banco favorecido
+        $this->add(21, 21, substr($codigoBarras, 3, 1));   // Moeda
+        $this->add(22, 22, substr($codigoBarras, 4, 1));   // DV código de barras
+        $this->add(23, 26, substr($codigoBarras, 5, 4));   // Fator de vencimento
+        $this->add(27, 36, substr($codigoBarras, 9, 10));  // Valor
+        $this->add(37, 61, substr($codigoBarras, 19, 25)); // Campo livre
+
+        // Nome do beneficiário (cedente do boleto)
+        $this->add(62, 91, Util::formatCnab('X', $pagamento->getBeneficiario()->getNome(), 30));
+
+        // Data de vencimento nominal
+        $dataVencimento = $pagamento->getDataVencimento()
+            ? $pagamento->getDataVencimento()->format('dmY')
+            : date('dmY');
+        $this->add(92, 99, Util::formatCnab('9L', $dataVencimento, 8));
+
+        // Valor nominal (do título)
+        $valorTitulo = (int) round(($pagamento->getValorTitulo() ?? $pagamento->getValor()) * 100);
+        $this->add(100, 114, Util::formatCnab('9L', $valorTitulo, 15));
+
+        // Descontos / Abatimentos
+        $valorDesconto = (int) round(($pagamento->getDesconto() ?? 0) * 100);
+        $this->add(115, 129, Util::formatCnab('9L', $valorDesconto, 15));
+
+        // Acréscimos (mora + multa)
+        $valorAcrescimo = (int) round(($pagamento->getAcrescimo() ?? 0) * 100);
+        $this->add(130, 144, Util::formatCnab('9L', $valorAcrescimo, 15));
+
+        // Data efetiva do pagamento
+        $dataPagamento = $pagamento->getDataPagamento()
+            ? $pagamento->getDataPagamento()->format('dmY')
+            : date('dmY');
+        $this->add(145, 152, Util::formatCnab('9L', $dataPagamento, 8));
+
+        // Valor efetivo do pagamento
+        $valorPagamento = (int) round($pagamento->getValor() * 100);
+        $this->add(153, 167, Util::formatCnab('9L', $valorPagamento, 15));
+
+        $this->add(168, 182, Util::formatCnab('9', '0', 15));                                               // 168-182: Zeros
+        $this->add(183, 202, Util::formatCnab('X', $pagamento->getNumeroControle() ?? '', 20));             // 183-202: Seu Número (nº doc atribuído pela empresa)
+        $this->add(203, 215, self::CAMPO_BRANCO);                                                           // 203-215: Brancos
+        $this->add(216, 230, self::CAMPO_BRANCO);                                                           // 216-230: Nosso Número (preenchido no retorno)
+        $this->add(231, 240, self::CAMPO_BRANCO);                                                           // 231-240: Ocorrências (preenchido no retorno)
+
+        return $this;
+    }
+
+    /**
+     * Segmento J-52 — Identificação do sacado/cedente/sacador avalista.
+     * Obrigatório para forma de lançamento 30 ou 31 (manual seção 5.1.4).
+     */
+    public function segmentoJ52($pagamento)
+    {
+        $this->iniciaDetalhe();
+
+        $sacado = $this->getPagador();
+        $tipoInscSacado = $sacado->getTipoDocumento() == 'CPF'
+            ? self::TIPO_DOCUMENTO_CPF
+            : self::TIPO_DOCUMENTO_CNPJ;
+
+        $cedente = $pagamento->getBeneficiario();
+        $tipoInscCedente = $cedente->getTipoDocumento() == 'CPF'
+            ? self::TIPO_DOCUMENTO_CPF
+            : self::TIPO_DOCUMENTO_CNPJ;
+
+        $sacadorAvalista = method_exists($pagamento, 'getSacadorAvalista')
+            ? $pagamento->getSacadorAvalista()
+            : null;
+
+        $this->add(1, 3, self::BANCO);                                                                      // 001-003: Banco
+        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);                                                   // 004-007: Lote
+        $this->add(8, 8, self::TIPO_REGISTRO_DETALHE);                                                      // 008-008: Tipo Registro (3)
+        $this->add(9, 13, Util::formatCnab('9L', $this->iSequencialPagamento, 5));                          // 009-013: Mesmo seq do J
+        $this->add(14, 14, self::CODIGO_SEGMENTO_J);                                                        // 014-014: Segmento (J)
+        $this->add(15, 17, Util::formatCnab('9L', '0', 3));                                                 // 015-017: Tipo Movimento
+        $this->add(18, 19, self::CODIGO_REGISTRO_OPCIONAL_J52);                                             // 018-019: Identificação Reg Opcional (52)
+
+        $this->add(20, 20, $tipoInscSacado);                                                                // 020-020: Tipo Insc Sacado
+        $this->add(21, 35, Util::formatCnab('9L', $sacado->getDocumento(), 15));                            // 021-035: Nº Inscrição Sacado
+        $this->add(36, 75, Util::formatCnab('X', $sacado->getNome(), 40));                                  // 036-075: Nome Sacado
+
+        $this->add(76, 76, $tipoInscCedente);                                                               // 076-076: Tipo Insc Cedente
+        $this->add(77, 91, Util::formatCnab('9L', $cedente->getDocumento(), 15));                           // 077-091: Nº Inscrição Cedente
+        $this->add(92, 131, Util::formatCnab('X', $cedente->getNome(), 40));                                // 092-131: Nome Cedente
+
+        if ($sacadorAvalista !== null) {
+            $tipoInscSacador = $sacadorAvalista->getTipoDocumento() == 'CPF'
+                ? self::TIPO_DOCUMENTO_CPF
+                : self::TIPO_DOCUMENTO_CNPJ;
+            $this->add(132, 132, $tipoInscSacador);
+            $this->add(133, 147, Util::formatCnab('9L', $sacadorAvalista->getDocumento(), 15));
+            $this->add(148, 187, Util::formatCnab('X', $sacadorAvalista->getNome(), 40));
+        } else {
+            $this->add(132, 132, '0');
+            $this->add(133, 147, Util::formatCnab('9', '0', 15));
+            $this->add(148, 187, self::CAMPO_BRANCO);
+        }
+
+        $this->add(188, 240, self::CAMPO_BRANCO);
+
+        return $this;
+    }
+
+    /**
+     * Trailer do lote.
+     */
+    protected function trailerLote()
+    {
+        $this->iniciaTrailerLote();
+
+        $this->add(1, 3, self::BANCO);
+        $this->add(4, 7, self::LOTE_SERVICO_HEADER_LOTE);
+        $this->add(8, 8, self::TIPO_REGISTRO_TRAILER_LOTE);
+        $this->add(9, 17, self::CAMPO_BRANCO);
+        $this->add(18, 23, Util::formatCnab('9L', $this->getCountRegistrosLote(), 6));
+        $this->add(24, 41, Util::formatCnab('9L', $this->getValorTotalLote(), 18));
+        $this->add(42, 59, Util::formatCnab('9', '0', 18));
+        $this->add(60, 230, self::CAMPO_BRANCO);
+        $this->add(231, 240, self::CAMPO_BRANCO);
+
+        return $this;
+    }
+
+    /**
+     * Trailer do arquivo.
+     */
+    protected function trailer()
+    {
+        $this->iniciaTrailer();
+
+        $this->add(1, 3, self::BANCO);
+        $this->add(4, 7, self::LOTE_SERVICO_TRAILER);
+        $this->add(8, 8, self::TIPO_REGISTRO_TRAILER_ARQUIVO);
+        $this->add(9, 17, self::CAMPO_BRANCO);
+        $this->add(18, 23, Util::formatCnab('9L', 1, 6));                                                   // Sempre 1 lote
+        $this->add(24, 29, Util::formatCnab('9L', $this->getCount(), 6));                                   // Total registros do arquivo
+        $this->add(30, 35, Util::formatCnab('9L', 0, 6));
+        $this->add(36, 240, self::CAMPO_BRANCO);
+
+        return $this;
+    }
+
+    protected function getCountDetalhes()
+    {
+        // Cada pagamento gera 2 segmentos (J + J-52)
+        return count($this->pagamentos) * 2;
+    }
+
+    protected function getCountRegistrosLote()
+    {
+        return $this->getCountDetalhes() + 2; // header + detalhes + trailer
+    }
+
+    protected function getValorTotalLote()
+    {
+        $valorTotal = 0;
+        foreach ($this->pagamentos as $pagamento) {
+            if (method_exists($pagamento, 'getValor') && $pagamento->getValor() > 0) {
+                $valorTotal += $pagamento->getValor();
+            }
+        }
+        return Util::formatCnab('9L', $valorTotal * 100, 18);
+    }
+
+    protected function getConvenio()
+    {
+        return $this->convenio ?? null;
+    }
+
+    public function setConvenio($convenio)
+    {
+        $this->convenio = $convenio;
+        return $this;
+    }
+
+    protected $convenio;
+}

--- a/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Pagamento/Cnab240/Banco/Ailos.php
@@ -130,7 +130,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
         $primeiroPagamento = $pagamentos[0] ?? null;
 
         if ($primeiroPagamento && method_exists($primeiroPagamento, 'getCodigoBarras')) {
-            return $this->ehBoletoAilos($primeiroPagamento)
+            return $this->isBoletoAilos($primeiroPagamento)
                 ? self::FORMA_LANCAMENTO_BOLETO_AILOS
                 : self::FORMA_LANCAMENTO_BOLETO_OUTROS;
         }
@@ -143,7 +143,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
      * posições do código de barras) ou de outro banco. Usado pelo agrupador
      * de lotes e pela escolha de forma de lançamento.
      */
-    protected function ehBoletoAilos($pagamento): bool
+    protected function isBoletoAilos($pagamento): bool
     {
         if (!method_exists($pagamento, 'getCodigoBarras')) {
             return false;
@@ -161,7 +161,7 @@ class Ailos extends AbstractPagamento implements PagamentoRemessaContract
      */
     protected function getTipoPagamentoDoPagamento(\Eduardokum\LaravelBoleto\Pagamento\Banco\Banco $pagamento)
     {
-        return $this->ehBoletoAilos($pagamento)
+        return $this->isBoletoAilos($pagamento)
             ? self::TIPO_PAGAMENTO_BOLETO_AILOS
             : self::TIPO_PAGAMENTO_BOLETO_OUTROS;
     }

--- a/src/Cnab/Pagamento/Retorno/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Pagamento/Retorno/Cnab240/Banco/Ailos.php
@@ -185,7 +185,7 @@ class Ailos extends AbstractRetorno
             ->setSeuNumero($seuNumero)
             ->setNumeroDocumento($partes[0] ?? '')
             ->setNumeroControle($partes[1] ?? '')
-            ->setNossoNumero(trim($this->rem(216, 230, $detalhe)))
+            ->setNossoNumero(trim($this->rem(203, 222, $detalhe)))
             ->setDataVencimento($this->rem(92, 99, $detalhe))
             ->setValorTitulo(Util::nFloat($this->rem(100, 114, $detalhe) / 100, 2, false))
             ->setDesconto(Util::nFloat($this->rem(115, 129, $detalhe) / 100, 2, false))
@@ -205,9 +205,7 @@ class Ailos extends AbstractRetorno
     protected function processarSegmentoJ52(array $detalhe, $d)
     {
         $tipoInscSacado = $this->rem(20, 20, $detalhe);
-        // NÃO usa ltrim('0') — CNPJs/CPFs que começam com zero ficariam com menos
-        // de 14/11 dígitos e Pessoa::setDocumento rejeita. trim() basta (espaços).
-        $docSacado      = trim($this->rem(21, 35, $detalhe));
+        $docSacado      = $this->extrairDocumentoJ52($this->rem(21, 35, $detalhe), $tipoInscSacado);
         $nomeSacado     = trim($this->rem(36, 75, $detalhe));
 
         if ($docSacado !== '' || $nomeSacado !== '') {
@@ -219,7 +217,7 @@ class Ailos extends AbstractRetorno
         }
 
         $tipoInscCedente = $this->rem(76, 76, $detalhe);
-        $docCedente      = trim($this->rem(77, 91, $detalhe));
+        $docCedente      = $this->extrairDocumentoJ52($this->rem(77, 91, $detalhe), $tipoInscCedente);
         $nomeCedente     = trim($this->rem(92, 131, $detalhe));
 
         if ($docCedente !== '' || $nomeCedente !== '') {
@@ -239,7 +237,7 @@ class Ailos extends AbstractRetorno
         }
 
         $tipoInscSacador = $this->rem(132, 132, $detalhe);
-        $docSacador      = trim($this->rem(133, 147, $detalhe));
+        $docSacador      = $this->extrairDocumentoJ52($this->rem(133, 147, $detalhe), $tipoInscSacador);
         $nomeSacador     = trim($this->rem(148, 187, $detalhe));
 
         if ($docSacador !== '' || $nomeSacador !== '') {
@@ -272,6 +270,30 @@ class Ailos extends AbstractRetorno
         }
 
         return true;
+    }
+
+    /**
+     * Documento do J-52 vem pad-zerado em 15 chars. Recorta pelo tipo de inscrição
+     * (1=CPF=11 dígitos, 2=CNPJ=14) preservando zeros legítimos. Tipo inválido ou
+     * documento todo zerado retorna '' — sinaliza ausência de Pessoa no segmento.
+     */
+    protected function extrairDocumentoJ52($raw, $tipoInsc)
+    {
+        $digitos = preg_replace('/\D/', '', (string) $raw);
+
+        if ($digitos === '' || ltrim($digitos, '0') === '') {
+            return '';
+        }
+
+        if ((string) $tipoInsc === '1') {
+            return substr($digitos, -11);
+        }
+
+        if ((string) $tipoInsc === '2') {
+            return substr($digitos, -14);
+        }
+
+        return '';
     }
 
     /**

--- a/src/Cnab/Pagamento/Retorno/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Pagamento/Retorno/Cnab240/Banco/Ailos.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Eduardokum\LaravelBoleto\Cnab\Pagamento\Retorno\Cnab240\Banco;
+
+use Illuminate\Support\Arr;
+use Eduardokum\LaravelBoleto\Util;
+use Eduardokum\LaravelBoleto\Exception\ValidationException;
+use Eduardokum\LaravelBoleto\Cnab\Pagamento\Retorno\Cnab240\Detalhe;
+use Eduardokum\LaravelBoleto\Cnab\Pagamento\Retorno\Cnab240\AbstractRetorno;
+
+/**
+ * Class Ailos
+ *
+ * Retorno CNAB 240 do Sistema Ailos (banco 085) para pagamento de títulos de
+ * cobrança. Manual "Pagamento por Arquivo - Layout 240 Posições" (versão 10,
+ * mai/2025), seções 5.1.3 (Segmento J), 5.1.4 (J-52) e 5.1.6 (J-99).
+ *
+ * @package Eduardokum\LaravelBoleto\Cnab\Pagamento\Retorno\Cnab240\Banco
+ */
+class Ailos extends AbstractRetorno
+{
+    protected $codigoBanco = '085';
+
+    /**
+     * Códigos de ocorrência (G059) conforme manual seção "Códigos de Ocorrências".
+     * Campo 231-240 do segmento J permite até 5 códigos concatenados (2 chars cada).
+     *
+     * @var array
+     */
+    private $ocorrencias = [
+        '00' => 'Débito Efetivado',
+        '01' => 'Insuficiência de Fundos (Débito não efetuado)',
+        '99' => 'Erro ao cadastrar agendamento',
+        'AG' => 'Agência/Conta Corrente/DV inválido',
+        'AH' => 'Nº Sequencial do Registro no Lote Inválido',
+        'AI' => 'Código de Segmento de Detalhe Inválido',
+        'AJ' => 'Tipo de Movimento Inválido',
+        'AP' => 'Data Lançamento Inválido',
+        'AR' => 'Valor do Lançamento Inválido',
+        'BD' => 'Inclusão Efetuada com Sucesso',
+        'BF' => 'Exclusão Efetuada com Sucesso',
+        'BI' => 'Beneficiário Divergente',
+        'CA' => 'Código de Barras - Código do Banco Inválido',
+        'CB' => 'Código de Barras - Código da Moeda Inválido',
+        'CC' => 'Código de Barras - Dígito Verificador Geral Inválido',
+        'CD' => 'Código de Barras - Valor do Título Inválido',
+        'CE' => 'Código de Barras - Campo Livre Inválido',
+        'CF' => 'Valor do Documento Inválido',
+        'CG' => 'Valor do Abatimento Inválido',
+        'CH' => 'Valor do Desconto Inválido',
+        'CI' => 'Valor da Mora Inválido',
+        'CJ' => 'Valor da Multa Inválido',
+        'HI' => 'Arquivo não Aceito',
+        'HJ' => 'Tipo de Registro Inválido',
+        'HK' => 'Código Remessa/Retorno Inválido',
+        'OD' => 'Agendamento não permitido após Vencimento',
+        'OE' => 'Somatória dos valores incorreta',
+        'OF' => 'Agendamento já existe',
+        'OG' => 'Banco não Encontrado',
+        'YA' => 'Título Não Encontrado',
+        'YD' => 'Código de Ocorrência Inválido',
+    ];
+
+    /**
+     * Mapeamento código → status conceitual do Detalhe.
+     * Códigos não listados são interpretados como rejeição.
+     */
+    private $statusOcorrencias = [
+        '00' => Detalhe::OCORRENCIA_PAGO,
+        'BD' => Detalhe::OCORRENCIA_PENDENTE,  // agendamento aceito, aguardando débito
+        'BF' => Detalhe::OCORRENCIA_CANCELADO, // exclusão de agendamento aceita
+    ];
+
+    private $incrementoInicioLote = 0;
+
+    protected function init()
+    {
+        $this->totais = [
+            'pagos'       => 0,
+            'rejeitados'  => 0,
+            'pendentes'   => 0,
+            'cancelados'  => 0,
+            'erros'       => 0,
+            'valor_total' => 0,
+        ];
+    }
+
+    protected function processarHeader(array $header)
+    {
+        $this->getHeader()
+            ->setCodBanco($this->rem(1, 3, $header))
+            ->setLoteServico($this->rem(4, 7, $header))
+            ->setTipoRegistro($this->rem(8, 8, $header))
+            ->setTipoInscricao($this->rem(18, 18, $header))
+            ->setNumeroInscricao($this->rem(19, 32, $header))
+            ->setAgencia($this->rem(53, 57, $header))
+            ->setConta($this->rem(59, 70, $header))
+            ->setContaDv($this->rem(71, 71, $header))
+            ->setNomeEmpresa($this->rem(73, 102, $header))
+            ->setNomeBanco($this->rem(103, 132, $header))
+            ->setCodigoRemessaRetorno($this->rem(143, 143, $header))
+            ->setData($this->rem(144, 151, $header))
+            ->setHora($this->rem(152, 157, $header))
+            ->setNumeroSequencialArquivo($this->rem(158, 163, $header))
+            ->setVersaoLayoutArquivo($this->rem(164, 166, $header));
+
+        return true;
+    }
+
+    protected function processarHeaderLote(array $headerLote)
+    {
+        $this->incrementoInicioLote = (int) $this->increment;
+
+        $this->getHeaderLote()
+            ->setCodBanco($this->rem(1, 3, $headerLote))
+            ->setNumeroLoteRetorno($this->rem(4, 7, $headerLote))
+            ->setTipoRegistro($this->rem(8, 8, $headerLote))
+            ->setTipoOperacao($this->rem(9, 9, $headerLote))
+            ->setTipoServico($this->rem(10, 11, $headerLote))
+            ->setFormaLancamento($this->rem(12, 13, $headerLote))
+            ->setVersaoLayoutLote($this->rem(14, 16, $headerLote))
+            ->setTipoInscricao($this->rem(18, 18, $headerLote))
+            ->setNumeroInscricao($this->rem(19, 32, $headerLote))
+            ->setAgencia($this->rem(53, 57, $headerLote))
+            ->setConta($this->rem(59, 70, $headerLote))
+            ->setContaDv($this->rem(71, 71, $headerLote))
+            ->setNomeEmpresa($this->rem(73, 102, $headerLote));
+
+        return true;
+    }
+
+    protected function processarDetalhe(array $detalhe)
+    {
+        $d = $this->detalheAtual();
+        $segmentType = $this->getSegmentType($detalhe);
+
+        if ($segmentType == 'J') {
+            $registroOpcional = $this->rem(18, 19, $detalhe);
+
+            // J-99 = registro de retorno com totais consolidados (manual seção 5.1.6)
+            if ($registroOpcional === '99') {
+                return $this->processarSegmentoJ99($detalhe, $d);
+            }
+
+            // J-52 = identificação sacado/cedente/sacador
+            if ($registroOpcional === '52') {
+                return $this->processarSegmentoJ52($detalhe, $d);
+            }
+
+            // J = liquidação propriamente dita
+            return $this->processarSegmentoJ($detalhe, $d);
+        }
+
+        return true;
+    }
+
+    /**
+     * Processa o segmento J - dados principais da liquidação de boleto.
+     */
+    protected function processarSegmentoJ(array $detalhe, $d)
+    {
+        $codigos = $this->parseCodigosOcorrencia($this->rem(231, 240, $detalhe));
+        $primary = $codigos[0] ?? '';
+
+        // Reconstrói o código de barras (44 dígitos) a partir das posições 018-061.
+        $codigoBarras = $this->rem(18, 20, $detalhe)
+            . $this->rem(21, 21, $detalhe)
+            . $this->rem(22, 22, $detalhe)
+            . $this->rem(23, 26, $detalhe)
+            . $this->rem(27, 36, $detalhe)
+            . $this->rem(37, 61, $detalhe);
+
+        // "Seu Número" (pos 183-202) é gravado pelo admin no formato "<batch_id>-<control_number>".
+        // Quebra para alimentar getNumeroDocumento (batch_id) e getNumeroControle (control_number).
+        $seuNumero = trim($this->rem(183, 202, $detalhe));
+        $partes = explode('-', $seuNumero);
+
+        $d->setCodigoBarras($codigoBarras)
+            ->setCodigoBancoFavorecido(substr($codigoBarras, 0, 3))
+            ->setOcorrencia($primary)
+            ->setOcorrenciaDescricao(Arr::get($this->ocorrencias, $primary, 'Desconhecida'))
+            ->setTipoMovimento(trim($this->rem(15, 17, $detalhe)))
+            ->setTipoPagamento('BOLETO')
+            ->setNomeFavorecido(trim($this->rem(62, 91, $detalhe)))
+            ->setSeuNumero($seuNumero)
+            ->setNumeroDocumento($partes[0] ?? '')
+            ->setNumeroControle($partes[1] ?? '')
+            ->setNossoNumero(trim($this->rem(216, 230, $detalhe)))
+            ->setDataVencimento($this->rem(92, 99, $detalhe))
+            ->setValorTitulo(Util::nFloat($this->rem(100, 114, $detalhe) / 100, 2, false))
+            ->setDesconto(Util::nFloat($this->rem(115, 129, $detalhe) / 100, 2, false))
+            ->setAcrescimo(Util::nFloat($this->rem(130, 144, $detalhe) / 100, 2, false))
+            ->setDataPagamento($this->rem(145, 152, $detalhe))
+            ->setValor(Util::nFloat($this->rem(153, 167, $detalhe) / 100, 2, false))
+            ->setValorRealEfetivado(Util::nFloat($this->rem(153, 167, $detalhe) / 100, 2, false));
+
+        $this->classificarOcorrencia($d, $codigos);
+
+        return true;
+    }
+
+    /**
+     * Processa o segmento J-52 - sacado / cedente / sacador avalista.
+     */
+    protected function processarSegmentoJ52(array $detalhe, $d)
+    {
+        $tipoInscSacado = $this->rem(20, 20, $detalhe);
+        // NÃO usa ltrim('0') — CNPJs/CPFs que começam com zero ficariam com menos
+        // de 14/11 dígitos e Pessoa::setDocumento rejeita. trim() basta (espaços).
+        $docSacado      = trim($this->rem(21, 35, $detalhe));
+        $nomeSacado     = trim($this->rem(36, 75, $detalhe));
+
+        if ($docSacado !== '' || $nomeSacado !== '') {
+            $d->setSacado([
+                'nome'          => $nomeSacado,
+                'documento'     => $docSacado,
+                'tipoDocumento' => $tipoInscSacado === '1' ? 'CPF' : 'CNPJ',
+            ]);
+        }
+
+        $tipoInscCedente = $this->rem(76, 76, $detalhe);
+        $docCedente      = trim($this->rem(77, 91, $detalhe));
+        $nomeCedente     = trim($this->rem(92, 131, $detalhe));
+
+        if ($docCedente !== '' || $nomeCedente !== '') {
+            $d->setCedente([
+                'nome'          => $nomeCedente,
+                'documento'     => $docCedente,
+                'tipoDocumento' => $tipoInscCedente === '1' ? 'CPF' : 'CNPJ',
+            ]);
+
+            if (! $d->getFavorecido()) {
+                $d->setFavorecido([
+                    'nome'          => $nomeCedente,
+                    'documento'     => $docCedente,
+                    'tipoDocumento' => $tipoInscCedente === '1' ? 'CPF' : 'CNPJ',
+                ]);
+            }
+        }
+
+        $tipoInscSacador = $this->rem(132, 132, $detalhe);
+        $docSacador      = trim($this->rem(133, 147, $detalhe));
+        $nomeSacador     = trim($this->rem(148, 187, $detalhe));
+
+        if ($docSacador !== '' || $nomeSacador !== '') {
+            $d->setSacadorAvalista([
+                'nome'          => $nomeSacador,
+                'documento'     => $docSacador,
+                'tipoDocumento' => $tipoInscSacador === '1' ? 'CPF' : 'CNPJ',
+            ]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Processa o segmento J-99 - retorno consolidado (manual seção 5.1.6).
+     * Geralmente carrega códigos adicionais de ocorrência ou totais finais.
+     * Campos exatos variam; mantemos o registro sem alterar o status (já
+     * definido pelo segmento J anterior).
+     */
+    protected function processarSegmentoJ99(array $detalhe, $d)
+    {
+        $codigos = $this->parseCodigosOcorrencia($this->rem(231, 240, $detalhe));
+
+        // Acumula códigos extras como rejeições adicionais (sem reclassificar status).
+        foreach ($codigos as $codigo) {
+            if (! isset($this->statusOcorrencias[$codigo])) {
+                $descricao = Arr::get($this->ocorrencias, $codigo, 'Código Desconhecido');
+                $d->addRejeicao($codigo, $descricao);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Extrai até 5 códigos de 2 caracteres do campo X(10) de ocorrências.
+     */
+    protected function parseCodigosOcorrencia($raw)
+    {
+        $padded = str_pad(substr((string) $raw, 0, 10), 10, ' ', STR_PAD_RIGHT);
+        $codes = [];
+        for ($i = 0; $i < 10; $i += 2) {
+            $code = trim(substr($padded, $i, 2));
+            if ($code !== '') {
+                $codes[] = $code;
+            }
+        }
+        return $codes;
+    }
+
+    /**
+     * Classifica a ocorrência (código primário define status; secundários
+     * viram rejeições adicionais como metadado).
+     */
+    protected function classificarOcorrencia($d, array $codigos)
+    {
+        $primary = $codigos[0] ?? '';
+
+        if ($primary === '') {
+            $d->setOcorrenciaTipo($d::OCORRENCIA_OUTROS);
+            return;
+        }
+
+        $status = Arr::get($this->statusOcorrencias, $primary, $d::OCORRENCIA_REJEITADO);
+        $d->setOcorrenciaTipo($status);
+
+        switch ($status) {
+            case $d::OCORRENCIA_PAGO:
+                $this->totais['pagos']++;
+                $this->totais['valor_total'] += $d->getValor();
+                break;
+            case $d::OCORRENCIA_PENDENTE:
+                $this->totais['pendentes']++;
+                break;
+            case $d::OCORRENCIA_CANCELADO:
+                $this->totais['cancelados']++;
+                break;
+            case $d::OCORRENCIA_REJEITADO:
+                $this->totais['rejeitados']++;
+                break;
+        }
+
+        foreach (array_slice($codigos, 1) as $codigo) {
+            if (! isset($this->statusOcorrencias[$codigo])) {
+                $descricao = Arr::get($this->ocorrencias, $codigo, 'Código Desconhecido');
+                $d->addRejeicao($codigo, $descricao);
+            }
+        }
+    }
+
+    protected function processarTrailerLote(array $trailerLote)
+    {
+        $qtdPagamentos = (int) $this->increment - (int) $this->incrementoInicioLote;
+
+        $this->getTrailerLote()
+            ->setCodBanco($this->rem(1, 3, $trailerLote))
+            ->setLoteServico($this->rem(4, 7, $trailerLote))
+            ->setTipoRegistro($this->rem(8, 8, $trailerLote))
+            ->setQtdRegistroLote((int) $this->rem(18, 23, $trailerLote))
+            ->setValorTotalPagamentos(Util::nFloat($this->rem(24, 41, $trailerLote) / 100, 2, false))
+            ->setQtdPagamentos($qtdPagamentos);
+
+        return true;
+    }
+
+    protected function processarTrailer(array $trailer)
+    {
+        $this->getTrailer()
+            ->setCodBanco($this->rem(1, 3, $trailer))
+            ->setNumeroLote($this->rem(4, 7, $trailer))
+            ->setTipoRegistro($this->rem(8, 8, $trailer))
+            ->setQtdLotesArquivo((int) $this->rem(18, 23, $trailer))
+            ->setQtdRegistroArquivo((int) $this->rem(24, 29, $trailer));
+
+        return true;
+    }
+}

--- a/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
@@ -54,10 +54,15 @@ class Ailos extends AbstractRemessa implements RemessaContract
      * Tipos de desconto suportados pela Ailos CNAB 240 (segmento P, pos 142).
      * Manual: somente "1 = Valor fixo até a data informada".
      *
+     * TIPO_DESCONTO_PERCENTUAL é aceito como atalho — a lib converte o
+     * percentual em R$ via resolveValorDescontoAbsoluto() antes de gravar
+     * o segmento P (tipo nativo continua sendo '1').
+     *
      * @var array<string, string>
      */
     protected $tiposDescontoSuportados = [
-        BoletoContract::TIPO_DESCONTO_VALOR_FIXO => '1',
+        BoletoContract::TIPO_DESCONTO_VALOR_FIXO   => '1',
+        BoletoContract::TIPO_DESCONTO_PERCENTUAL   => '1',
     ];
 
     /**
@@ -459,8 +464,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
         $this->add(8, 8, '5');
         $this->add(9, 17, '');
         $this->add(18, 23, Util::formatCnab('9', $this->getCountDetalhes() + 2, 6));
-        $this->add(24, 29, Util::formatCnab('9', 0, 6));
-        $this->add(30, 46, Util::formatCnab('9', 0, 17, 2));
+        $this->add(24, 29, Util::formatCnab('9', count($this->boletos), 6));
+        $this->add(30, 46, Util::formatCnab('9', $valor, 17, 2));
         $this->add(47, 52, Util::formatCnab('9', 0, 6));
         $this->add(53, 69, Util::formatCnab('9', 0, 17, 2));
         $this->add(70, 75, Util::formatCnab('9', 0, 6));
@@ -491,5 +496,42 @@ class Ailos extends AbstractRemessa implements RemessaContract
         $this->add(36, 240, '');
 
         return $this;
+    }
+
+    /**
+     * Sobrescreve o preenchimento padrão do desconto (segmento P, pos 142-165).
+     * Ailos só aceita "1 = Valor fixo" no tipo nativo — quando o boleto vem
+     * com TIPO_DESCONTO_PERCENTUAL, a lib converte o percentual em R$ via
+     * resolveValorDescontoAbsoluto() para que o consumidor passe apenas o
+     * código canônico e a lib produza o valor exigido pelo layout.
+     *
+     * @param BoletoContract $boleto
+     * @throws ValidationException
+     */
+    protected function preencheDescontoSegmentoP(BoletoContract $boleto)
+    {
+        $codigoCanonico = (string) $boleto->getDescontoCodigo();
+
+        if ($codigoCanonico === BoletoContract::TIPO_DESCONTO_NENHUM && $boleto->getDesconto() > 0) {
+            $codigoCanonico = BoletoContract::TIPO_DESCONTO_VALOR_FIXO;
+        }
+
+        $valor = $this->resolveValorDescontoAbsoluto($boleto);
+
+        if ($codigoCanonico === BoletoContract::TIPO_DESCONTO_NENHUM || $valor <= 0) {
+            $this->add(142, 142, '0');
+            $this->add(143, 150, '00000000');
+            $this->add(151, 165, Util::formatCnab('9', 0, 15, 2));
+
+            return;
+        }
+
+        $dataDesconto = $boleto->getDataDesconto()
+            ? $boleto->getDataDesconto()->format('dmY')
+            : '00000000';
+
+        $this->add(142, 142, '1');
+        $this->add(143, 150, $dataDesconto);
+        $this->add(151, 165, Util::formatCnab('9', $valor, 15, 2));
     }
 }

--- a/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
@@ -28,7 +28,6 @@ class Ailos extends AbstractRemessa implements RemessaContract
     const PROTESTO_SEM = '3';
     const PROTESTO_DIAS_CORRIDOS = '1';
     const PROTESTO_NAO_PROTESTAR = '3';
-    const PROTESTO_AUTOMATICO = '9';
 
     public function __construct(array $params = [])
     {
@@ -239,7 +238,7 @@ class Ailos extends AbstractRemessa implements RemessaContract
         }
         $this->add(222, 223, Util::formatCnab('9', $boleto->getDiasProtesto(), 2));
         $this->add(224, 224, '2'); // Deverá ser informado o código ‘2’, visto que o sistema respeita o decurso de prazo cadastrado no convênio do cooperado..
-        $this->add(225, 227, ''); // Utilizar sempre, nesse campo, 60 dias para baixa/devolução.
+        $this->add(225, 227, '000'); // Manual exige "000" — sistema respeita o decurso de prazo cadastrado no convênio do cooperado.
         $this->add(228, 229, Util::formatCnab('9', $boleto->getMoeda(), 2));
         $this->add(230, 239, '0000000000');
         $this->add(240, 240, '');
@@ -255,7 +254,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
      */
     protected function segmentoR(BoletoContract $boleto)
     {
-        if (!$boleto->getMulta() > 0 && !$boleto->getDesconto() > 0) {
+        // Manual Ailos CNAB 240 (seção 4.2.2.6): segmento R é exclusivo para multa.
+        if (!($boleto->getMulta() > 0)) {
             return $this;
         }
 
@@ -280,18 +280,13 @@ class Ailos extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
 
+        // Desconto 2 e Desconto 3 não são utilizados pela Ailos — zerar conforme manual.
         $this->add(18, 18, '0');
         $this->add(19, 26, '00000000');
         $this->add(27, 41, Util::formatCnab('9', 0, 15, 2));
-        if ($boleto->getDesconto() > 0) {
-            $this->add(18, 18, '1'); // '1' = Valor fixo até a data informada
-            $this->add(19, 26, $boleto->getDataDesconto() ? $boleto->getDataDesconto()->format('dmY') : $boleto->getDataVencimento()->format('dmY'));
-            $this->add(27, 41, Util::formatCnab('9', $boleto->getMulta(), 15, 2));
-        }
-
         $this->add(42, 42, '0');
-        $this->add(43, 50, Util::formatCnab('9', 0, 8));
-        $this->add(51, 65, Util::formatCnab('9', 0, 15));
+        $this->add(43, 50, '00000000');
+        $this->add(51, 65, Util::formatCnab('9', 0, 15, 2));
         $this->add(66, 66, '0');
         $this->add(67, 74, '00000000');
         $this->add(75, 89, Util::formatCnab('9', 0, 15, 2));

--- a/src/Util.php
+++ b/src/Util.php
@@ -1124,20 +1124,29 @@ final class Util
      */
     public static function adiciona(&$line, $i, $f, $value)
     {
+        $iOriginal = $i;
         $i--;
 
         if (($i > 398 || $f > 400) && ($i != 401 && $f != 444)) {
-            throw new ValidationException('$ini ou $fim ultrapassam o limite máximo de 400');
+            throw new ValidationException(sprintf('Posições inválidas: $ini=%d e $fim=%d ultrapassam o limite máximo de 400', $iOriginal, $f));
         }
 
         if ($f < $i) {
-            throw new ValidationException('$ini é maior que o $fim');
+            throw new ValidationException(sprintf('Posições inválidas: $ini=%d é maior que $fim=%d', $iOriginal, $f));
         }
 
         $t = $f - $i;
 
         if (mb_strlen($value) > $t) {
-            throw new ValidationException(sprintf('String $valor maior que o tamanho definido em $ini e $fim: $valor=%s e tamanho é de: %s', mb_strlen($value), $t));
+            $valuePreview = mb_strlen($value) > 60 ? mb_substr($value, 0, 60) . '...' : $value;
+            throw new ValidationException(sprintf(
+                'Valor "%s" (%d caracteres) excede o tamanho do campo nas posições %d-%d (cabem %d caracteres). Verifique se o dado de entrada (agência, conta, DV, convênio, nome, etc.) está no formato esperado pelo banco.',
+                $valuePreview,
+                mb_strlen($value),
+                $iOriginal,
+                $f,
+                $t
+            ));
         }
 
         $value = sprintf("%{$t}s", $value);


### PR DESCRIPTION
Adicionada a integração com a Viacredi e demais cooperativas do conglomerado Ailos (código 085) em Financeiro » Configurações » Métodos de Cobrança, Financeiro » Integrações » Remessas » Cobranças e Financeiro » Integrações » Remessas » Pagamentos; na cobrança, o método tipo Boleto Externo passa a pedir só o convênio, fixar o layout em CNAB240 e permitir gerar e baixar remessa de boletos para o banco, convertendo desconto percentual em valor fixo em reais quando a fatura tiver desconto assim configurado; no pagamento, a conta da cooperativa deixa de exibir "banco não mapeado" e passa a exportar arquivo CNAB 240 de pagamento de boletos com os segmentos exigidos pelo manual Ailos (J e J-52), usando forma de lançamento 30 para boleto da própria Ailos e 31 para boleto de outro banco.