### PR TITLE
fix/banrisul-adjusts-generate-batch

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
@@ -9,179 +9,110 @@ use Eduardokum\LaravelBoleto\Contracts\Boleto\Boleto as BoletoContract;
 use Eduardokum\LaravelBoleto\Contracts\Cnab\Remessa as RemessaContract;
 
 /**
- * Remessa CNAB 240 - Banrisul
+ * Remessa CNAB 240 - Banrisul (Cobrança)
  *
- * Implementação baseada no manual oficial:
- *   "Cobrança Banrisul - Leiaute Padrão Febraban CNAB 240 Posições - Versão 10.3"
- *   Atualizado em 08/04/2025.
+ * Implementação fiel ao manual oficial de cobrança:
+ *   "Cobrança Banrisul - Leiaute CNAB 240 Posições Padrão Febraban"
+ *   (arquivo manuais/BANRISUL/240_posicoes.pdf)
+ *   Layout de arquivo 040, layout de lote 020.
  *
- * Códigos das constantes referenciam os campos descritos no manual:
- *   C004 - Movimento; C006 - Carteira; C015 - Espécie; C018 - Juros;
- *   C021 - Desconto; C026 - Protesto/Negativação; C028 - Baixa/Devolução;
- *   C030 - Espécie de Cobrança; C077 - Pagamento Parcial; G019 - Layout Arquivo;
- *   G030 - Layout Lote; G065 - Moeda; G103 - Tipo de Chave PIX.
+ * IMPORTANTE: este manual é diferente do "v10.3 / 08-04-2025" (que possui PIX,
+ * segmento Y-53, espécie de cobrança de 10 dígitos, negativação, pagamento
+ * parcial). Nada disso existe neste leiaute e portanto não é tratado aqui.
+ *
+ * Referências de campo (coluna "Nº/REG" do manual):
+ *   07.3P Código de movimento; 14.3P Carteira; 24.3P Espécie do título;
+ *   27/28/29.3P Juros; 30/31/32.3P Desconto 1; 37/38.3P Protesto;
+ *   39.3P Baixa/Devolução; 40.3P Moeda; 14/15/16.3R Multa.
  */
 class Banrisul extends AbstractRemessa implements RemessaContract
 {
     /**
-     * Manual (240 posições): convênio é numérico (20) mas o Banrisul considera
-     * as 13 primeiras posições. Para não deixar espaços (que invalidam campo
-     * numérico), preenchemos 13 dígitos + 7 zeros.
-     *
-     * @return string
+     * Códigos de movimento (campo 07.3P do manual).
      */
-    protected function getConvenioCnab20()
-    {
-        $c = Util::onlyNumbers($this->getCodigoCliente());
-        $c13 = substr($c, 0, 13);
-        $c13 = str_pad($c13, 13, '0', STR_PAD_LEFT);
-
-        return $c13 . '0000000';
-    }
+    const OCORRENCIA_REMESSA = '01';                 // Entrada de títulos
+    const OCORRENCIA_PEDIDO_BAIXA = '02';            // Pedido de baixa
+    const OCORRENCIA_CONCESSAO_ABATIMENTO = '04';    // Concessão de abatimento
+    const OCORRENCIA_CANC_ABATIMENTO = '05';         // Cancelamento de abatimento
+    const OCORRENCIA_ALT_VENCIMENTO = '06';          // Alteração de vencimento
+    const OCORRENCIA_PROTESTAR = '09';               // Protestar imediatamente
+    const OCORRENCIA_SUSTAR_PROTESTO = '10';         // Sustação da instrução de protesto
+    const OCORRENCIA_REEMBOLSO_TRANSFERENCIA = '12'; // Reembolso/transf. p/ cobrança simples (Desconto/Vendor)
+    const OCORRENCIA_REEMBOLSO_DEVOLUCAO = '13';     // Reembolso/devolução (Desconto/Vendor)
+    const OCORRENCIA_PROTESTO_FALENCIA = '15';       // Protesto imediato por motivo de falência
+    const OCORRENCIA_ALT_OUTROS_DADOS = '31';        // Alteração de outros dados
 
     /**
-     * Códigos de movimento (campo C004 do manual)
-     */
-    const OCORRENCIA_REMESSA = '01';
-    const OCORRENCIA_PEDIDO_BAIXA = '02';
-    const OCORRENCIA_CONCESSAO_ABATIMENTO = '04';
-    const OCORRENCIA_CANC_ABATIMENTO = '05';
-    const OCORRENCIA_ALT_VENCIMENTO = '06';
-    const OCORRENCIA_CONCESSAO_DESCONTO = '07';
-    const OCORRENCIA_CANC_DESCONTO = '08';
-    const OCORRENCIA_PROTESTAR = '09';
-    const OCORRENCIA_SUSTAR_PROTESTO_BAIXAR = '10';
-    const OCORRENCIA_SUSTAR_PROTESTO_MANTER = '11';
-    const OCORRENCIA_ALT_JUROS = '12';
-    const OCORRENCIA_DISPENSA_JUROS = '13';
-    const OCORRENCIA_ALT_MULTA = '14';
-    const OCORRENCIA_DISPENSA_MULTA = '15';
-    const OCORRENCIA_ALT_DESCONTO = '16';
-    const OCORRENCIA_NAO_CONCEDER_DESCONTO = '17';
-    const OCORRENCIA_ALT_ABATIMENTO = '18';
-    const OCORRENCIA_ALT_NUMERO_CONTROLE = '22';
-    const OCORRENCIA_ALT_PAGADOR = '23';
-    const OCORRENCIA_ALT_SACADOR = '24';
-    const OCORRENCIA_ALT_OUTROS_DADOS = '31';
-    const OCORRENCIA_TRANS_CARTEIRA = '43';
-    const OCORRENCIA_NEGATIVAR = '45';
-    const OCORRENCIA_RETIRAR_NEGATIVACAO = '46';
-    const OCORRENCIA_ALT_VLR_MIN_PERC = '48';
-    const OCORRENCIA_ALT_VLR_MAX_PERC = '49';
-
-    /**
-     * Códigos de protesto / negativação (campo C026 do manual)
-     */
-    const PROTESTO_DIAS_CORRIDOS = '1';
-    const PROTESTO_NAO_PROTESTAR = '3';
-    const PROTESTO_NAO_NEGATIVAR = '7';
-    const PROTESTO_NEGATIVAR_DIAS_CORRIDOS = '8';
-
-    /**
-     * Códigos de baixa / devolução (campo C028 do manual)
-     */
-    const BAIXA_DEVOLVER = '1';
-    const BAIXA_CANCELAR_PRAZO = '3';
-
-    /**
-     * Códigos de juros de mora (campo C018 do manual)
+     * Códigos de juros de mora (campo 27.3P do manual).
+     * Obs.: o código 3 é "Reservado" neste leiaute; para "sem juros" usamos 0.
      */
     const JUROS_VALOR_DIA = '1';
     const JUROS_TAXA_MENSAL = '2';
-    const JUROS_ISENTO = '3';
 
     /**
-     * Códigos de desconto (campo C021 do manual)
+     * Códigos de desconto 1 (campo 30.3P do manual).
+     * 4 e 6 são reservados/não tratados pelo banco.
      */
-    const DESCONTO_VALOR_FIXO = '1';
-    const DESCONTO_PERCENTUAL = '2';
-    const DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO = '3';
-    const DESCONTO_PERCENTUAL_DIA_CORRIDO = '5';
-    const DESCONTO_CANCELAMENTO = '7';
+    const DESCONTO_VALOR_FIXO = '1';                       // Valor fixo até a data informada
+    const DESCONTO_PERCENTUAL = '2';                       // Percentual até a data informada
+    const DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO = '3';    // Valor por antecipação dia corrido
+    const DESCONTO_PERCENTUAL_DIA_CORRIDO = '5';           // Percentual sobre o valor nominal dia corrido
 
     /**
-     * Códigos de multa (campo G073 do manual)
+     * Códigos de protesto (campo 37.3P do manual).
+     */
+    const PROTESTO_DIAS_CORRIDOS = '1';
+    const PROTESTO_NAO_PROTESTAR = '3';
+
+    /**
+     * Código de baixa/devolução (campo 39.3P do manual).
+     */
+    const BAIXA_DEVOLVER = '1';
+
+    /**
+     * Códigos de multa (campo 14.3R do manual).
      */
     const MULTA_VALOR_FIXO = '1';
-    const MULTA_PERCENTUAL = '2';
+    const MULTA_PERCENTUAL_MES = '2';
+    const MULTA_PERCENTUAL = '3';
 
     /**
-     * Códigos de espécie de cobrança (campo C030 do manual)
-     */
-    const ESPECIE_COBRANCA_SIMPLES = '0000805076';
-    const ESPECIE_COBRANCA_SEGURADORAS = '0000805157';
-    const ESPECIE_COBRANCA_FINANCEIRAS = '0000805238';
-    const ESPECIE_COBRANCA_PARTILHADA = '0000815470';
-    const ESPECIE_COBRANCA_SIMPLES_DOLAR = '0000825468';
-    const ESPECIE_COBRANCA_DESCONTO = '0000603015';
-
-    /**
-     * Identificações de Tipo de Pagamento (campo C078 do manual - segmento Y-53)
-     */
-    const TP_PAGTO_QUALQUER_VALOR = '01';
-    const TP_PAGTO_ENTRE_MIN_MAX = '02';
-    const TP_PAGTO_NAO_DIVERGENTE = '03';
-
-    /**
-     * Pagamento parcial (campo C077 do manual)
-     */
-    const PAGAMENTO_PARCIAL_NAO = '1';
-    const PAGAMENTO_PARCIAL_SIM = '2';
-
-    /**
-     * Código do banco
+     * Código do banco.
      *
      * @var string
      */
     protected $codigoBanco = BoletoContract::COD_BANCO_BANRISUL;
 
     /**
-     * Carteiras suportadas pelo CNAB 240 do Banrisul (campo C006 do manual).
-     *
-     * 1 -> Cobrança Simples
-     * 2 -> Cobrança Vinculada (apenas clientes previamente autorizados)
-     * 3 -> Cobrança Caucionada (apenas clientes previamente autorizados)
-     * 4 -> Cobrança Descontada
-     *
-     * Carteira 5 (Vendor) não é tratada pelo Banrisul.
+     * Carteiras suportadas (campo 14.3P do manual). Não existe carteira "4".
      *
      * @var array
      */
-    protected $carteiras = ['1', '2', '3', '4'];
+    protected $carteiras = ['1', '2', '3', 'B', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'N', 'P', 'R', 'S', 'T', 'U'];
 
     /**
-     * Tipos de desconto suportados pelo Banrisul CNAB 240 (campo C021).
+     * Tipos de desconto canônicos suportados por este leiaute (campo 30.3P).
      *
-     * O manual não diferencia "dia útil" de "dia corrido" para os tipos
-     * fixo/antecipação e percentual sobre valor: as variantes canônicas
-     * "dia útil" (4 e 6) são mapeadas para os equivalentes "dia corrido"
-     * (3 e 5) já tratados pelo banco.
+     * As variantes "dia útil" (códigos 4 e 6) são reservadas/não tratadas pelo
+     * banco e por isso são mapeadas para os equivalentes "dia corrido" (3 e 5).
      *
      * @var array<string, string>
      */
     protected $tiposDescontoSuportados = [
-        BoletoContract::TIPO_DESCONTO_VALOR_FIXO                      => self::DESCONTO_VALOR_FIXO,
-        BoletoContract::TIPO_DESCONTO_PERCENTUAL                      => self::DESCONTO_PERCENTUAL,
-        BoletoContract::TIPO_DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO   => self::DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO,
-        BoletoContract::TIPO_DESCONTO_VALOR_ANTECIPACAO_DIA_UTIL      => self::DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO,
-        BoletoContract::TIPO_DESCONTO_PERCENTUAL_DIA_CORRIDO          => self::DESCONTO_PERCENTUAL_DIA_CORRIDO,
-        BoletoContract::TIPO_DESCONTO_PERCENTUAL_DIA_UTIL             => self::DESCONTO_PERCENTUAL_DIA_CORRIDO,
-        BoletoContract::TIPO_DESCONTO_CANCELAMENTO                    => self::DESCONTO_CANCELAMENTO,
+        BoletoContract::TIPO_DESCONTO_VALOR_FIXO                    => self::DESCONTO_VALOR_FIXO,
+        BoletoContract::TIPO_DESCONTO_PERCENTUAL                    => self::DESCONTO_PERCENTUAL,
+        BoletoContract::TIPO_DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO => self::DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO,
+        BoletoContract::TIPO_DESCONTO_VALOR_ANTECIPACAO_DIA_UTIL    => self::DESCONTO_VALOR_ANTECIPACAO_DIA_CORRIDO,
+        BoletoContract::TIPO_DESCONTO_PERCENTUAL_DIA_CORRIDO        => self::DESCONTO_PERCENTUAL_DIA_CORRIDO,
+        BoletoContract::TIPO_DESCONTO_PERCENTUAL_DIA_UTIL           => self::DESCONTO_PERCENTUAL_DIA_CORRIDO,
     ];
 
     /**
-     * Código do beneficiário no Banrisul (13 dígitos, fornecido pelo banco).
+     * Código do beneficiário no Banrisul (convênio - 13 dígitos, campo 07.0/11.1).
      *
      * @var string
      */
     protected $codigoCliente;
-
-    /**
-     * Espécie de cobrança (campo C030 do manual). Default = Cobrança Simples.
-     *
-     * @var string
-     */
-    protected $codigoEspecieCobranca = self::ESPECIE_COBRANCA_SIMPLES;
 
     public function __construct(array $params = [])
     {
@@ -210,28 +141,19 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
+     * Convênio (campos 07.0 e 11.1 do manual): campo numérico de 20 posições do
+     * qual o Banrisul considera apenas as 13 PRIMEIRAS posições. Para manter o
+     * campo numérico válido (regra 2.3-3: numérico não utilizado = zeros),
+     * gravamos os 13 dígitos do código do beneficiário seguidos de 7 zeros.
+     *
      * @return string
      */
-    public function getCodigoEspecieCobranca()
+    protected function getConvenioCnab20()
     {
-        // Quando a carteira for desconto, força código próprio (manual C030).
-        if ((string) $this->getCarteira() === '4') {
-            return self::ESPECIE_COBRANCA_DESCONTO;
-        }
+        $c = Util::onlyNumbers($this->getCodigoCliente());
+        $c13 = str_pad(substr($c, 0, 13), 13, '0', STR_PAD_LEFT);
 
-        return $this->codigoEspecieCobranca;
-    }
-
-    /**
-     * @param string $codigoEspecieCobranca
-     *
-     * @return $this
-     */
-    public function setCodigoEspecieCobranca($codigoEspecieCobranca)
-    {
-        $this->codigoEspecieCobranca = Util::formatCnab('9', Util::onlyNumbers($codigoEspecieCobranca), 10);
-
-        return $this;
+        return $c13 . '0000000';
     }
 
     /**
@@ -251,9 +173,11 @@ class Banrisul extends AbstractRemessa implements RemessaContract
             $this->segmentoR($boleto);
         }
 
+        // Títulos de terceiros (espécie "AD"): manual (3.4/3.7) exige o nome do
+        // Sacador/Avalista no segmento Q (170-209) e a inclusão do segmento Y.
         $especie = (string) $boleto->getEspecieDocCodigo(99, 240);
         if ($especie === 'AD' && ! $boleto->getSacadorAvalista()) {
-            throw new ValidationException('Banrisul CNAB240: Espécie "AD" (título de terceiros) exige Sacador/Avalista e inclusão do Segmento Y-01, conforme manual.');
+            throw new ValidationException('Banrisul CNAB240: Espécie "AD" (título de terceiros) exige Sacador/Avalista e inclusão do Segmento Y, conforme manual.');
         }
 
         if ($boleto->getSacadorAvalista() || $especie === 'AD') {
@@ -264,23 +188,38 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
-     * O segmento R é necessário quando há multa ou mensagens 3/4 a serem
-     * impressas no boleto. Para a carteira de desconto (4), o manual proíbe.
+     * Segmento R é opcional: necessário para enviar multa ou mensagens (3/4).
      *
      * @param BoletoContract $boleto
      * @return bool
      */
     protected function precisaSegmentoR(BoletoContract $boleto)
     {
-        if ((string) $this->getCarteira() === '4') {
-            return false;
+        if ($boleto->getMulta() > 0) {
+            return true;
         }
 
-        return $boleto->getMulta() > 0;
+        $instrucoes = array_filter((array) $boleto->getInstrucoes(), function ($i) {
+            return trim((string) $i) !== '';
+        });
+
+        return count($instrucoes) > 0;
     }
 
     /**
-     * Resolve o código de movimento (16-17) baseado no status do boleto.
+     * Carteiras de desconto/vendor eletrônico (R e S). Nestes casos o manual
+     * determina deixar em branco os campos de juros, desconto, IOF e protesto
+     * do Segmento P (a taxa da operação é informada no Segmento R, 75-89).
+     *
+     * @return bool
+     */
+    protected function isCarteiraEletronica()
+    {
+        return in_array((string) $this->getCarteira(), ['R', 'S'], true);
+    }
+
+    /**
+     * Resolve o código de movimento (campo 07.3P) a partir do status do boleto.
      *
      * @param BoletoContract $boleto
      * @return string
@@ -302,7 +241,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
-     * Tipo de inscrição: 1 = CPF, 2 = CNPJ (campo G005 do manual).
+     * Tipo de inscrição: 1 = CPF, 2 = CNPJ (campo G005 / 05.0 do manual).
      *
      * @param string|null $documento
      * @return int
@@ -313,6 +252,152 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
+     * Normaliza o código da moeda (campo 40.3P): códigos numéricos ocupam 2
+     * posições (ex.: 09 = Real). Default = 09 quando não informado.
+     *
+     * @param BoletoContract $boleto
+     * @return string
+     */
+    protected function getCodigoMoeda(BoletoContract $boleto)
+    {
+        $moeda = strtoupper(trim((string) $boleto->getMoeda()));
+
+        if ($moeda === '') {
+            return '09';
+        }
+
+        if (ctype_digit($moeda) && strlen($moeda) === 1) {
+            return '0' . $moeda;
+        }
+
+        return $moeda;
+    }
+
+    /**
+     * Manual seção 2: campos alfanuméricos não devem conter acentuação,
+     * pontuação ou caracteres especiais — podem rejeitar a remessa. Substitui
+     * por espaço para preservar a separação entre palavras.
+     *
+     * @param string|null $value
+     * @return string
+     */
+    protected function sanitizeAlfa($value)
+    {
+        // Translitera acentos para ASCII (José -> JOSE) ANTES de remover os demais caracteres; senão a letra acentuada viraria espaço e corromperia o nome. Util::upper resolve acentos minúsculos; normalizeChars converte para ASCII.
+        $value = Util::normalizeChars(Util::upper((string) $value));
+
+        return preg_replace('/[^A-Za-z0-9 \-]/', ' ', $value);
+    }
+
+    /**
+     * @return $this
+     * @throws ValidationException
+     */
+    protected function header()
+    {
+        $this->iniciaHeader();
+
+        // Controle (1-8)
+        $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco())); // 041
+        $this->add(4, 7, '0000');                                     // Lote de serviço
+        $this->add(8, 8, '0');                                        // Registro Header de Arquivo
+        // CNAB (9-17) - BRANCOS
+        $this->add(9, 17, '');
+
+        // Empresa (18-72)
+        $this->add(18, 18, $this->getTipoInscricao($this->getBeneficiario()->getDocumento()));
+        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        // Convênio (33-52): numérico, 13 primeiras posições.
+        $this->add(33, 52, $this->getConvenioCnab20());
+        // Conta (53-72): no HEADER DE ARQUIVO estes campos SÃO considerados pelo
+        // banco (diferente do Header de Lote). Agência "0AAAA", conta numérica.
+        $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
+        $this->add(58, 58, '');                                       // DV agência - BRANCO
+        $this->add(59, 70, Util::formatCnab('9', $this->getConta(), 12));
+        $this->add(71, 71, Util::formatCnab('9', $this->getContaDv(), 1)); // DV conta - Numérico
+        $this->add(72, 72, '');                                       // DV ag/conta - BRANCO
+
+        // Nome do beneficiário (73-102) e nome do banco (103-132)
+        $this->add(73, 102, Util::formatCnab('X', $this->sanitizeAlfa($this->getBeneficiario()->getNome()), 30));
+        $this->add(103, 132, Util::formatCnab('X', 'BANRISUL', 30));
+
+        // CNAB (133-142) - BRANCOS
+        $this->add(133, 142, '');
+
+        // Arquivo (143-171)
+        $this->add(143, 143, '1');                       // 1 = Remessa
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
+        $this->add(152, 157, date('His'));
+        $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
+        $this->add(164, 166, '040');                     // Layout do arquivo
+        $this->add(167, 171, '00000');                   // Densidade
+
+        // Reservado Banco (172-191)
+        $this->add(172, 179, '');
+        $this->add(180, 181, 'BE');                      // Uso reservado do Banco - remessa
+        $this->add(182, 191, '');
+
+        // Reservado empresa (192-211) - BRANCOS
+        $this->add(192, 211, '');
+        // VANS / serviço (212-240) - não considerado, BRANCOS
+        $this->add(212, 240, '');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     * @throws ValidationException
+     */
+    protected function headerLote()
+    {
+        $this->iniciaHeaderLote();
+
+        $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
+        $this->add(4, 7, '0001');
+        $this->add(8, 8, '1');                                        // Registro Header de Lote
+
+        // Serviço (9-17)
+        $this->add(9, 9, 'R');                                        // R = Remessa
+        $this->add(10, 11, '01');                                     // Tipo de serviço
+        $this->add(12, 13, '00');                                     // Forma de lançamento
+        $this->add(14, 16, '020');                                    // Layout do lote
+        $this->add(17, 17, '');
+
+        // Empresa (18-73) - tipo/número de inscrição não considerados, mas
+        // numéricos: preenchemos com os dados reais (válido) por consistência.
+        $this->add(18, 18, $this->getTipoInscricao($this->getBeneficiario()->getDocumento()));
+        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(34, 53, $this->getConvenioCnab20());
+        // Conta (54-73): no Header de Lote são "não considerados". Numérico não
+        // utilizado = zeros; DVs alfanuméricos = brancos.
+        $this->add(54, 58, Util::formatCnab('9', 0, 5));
+        $this->add(59, 59, '');
+        $this->add(60, 71, Util::formatCnab('9', 0, 12));
+        $this->add(72, 72, '');
+        $this->add(73, 73, '');
+
+        $this->add(74, 103, Util::formatCnab('X', $this->sanitizeAlfa($this->getBeneficiario()->getNome()), 30));
+
+        // Mensagens 1 e 2 (104-183) - opcionais
+        $this->add(104, 143, '');
+        $this->add(144, 183, '');
+
+        // Controle cobrança (184-207)
+        $this->add(184, 191, Util::formatCnab('9', $this->getIdremessa(), 8));   // Nº remessa
+        $this->add(192, 199, $this->getDataRemessa('dmY'));                       // Data de gravação
+        // Data do crédito (200-207) - não considerado na remessa. Numérico = zeros.
+        $this->add(200, 207, Util::formatCnab('9', 0, 8));
+
+        // CNAB final (208-240) - BRANCOS
+        $this->add(208, 240, '');
+
+        return $this;
+    }
+
+    /**
+     * Segmento P (registro 3, obrigatório) - manual 3.3.
+     *
      * @param BoletoContract $boleto
      *
      * @return $this
@@ -322,83 +407,82 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     {
         $this->iniciaDetalhe();
         $movimento = $this->getCodigoMovimento($boleto);
-        $moeda = (string) $boleto->getMoeda();
+        $moeda = $this->getCodigoMoeda($boleto);
+        // Moeda 02 (dólar): valor com 4 casas decimais; demais com 2 (manual 21.3P).
+        $decValor = $moeda === '02' ? 4 : 2;
 
-        // Controle (1-15)
+        // Controle (1-17)
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
         $this->add(4, 7, '0001');
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'P');
         $this->add(15, 15, '');
-        // Código de movimento (16-17)
         $this->add(16, 17, $movimento);
 
-        // Conta corrente (18-37) - Manual: campo não considerado (Brancos*)
-        $this->add(18, 22, '');
+        // Conta corrente (18-37) - não considerado. Numérico = zeros; DVs = brancos.
+        $this->add(18, 22, Util::formatCnab('9', 0, 5));
         $this->add(23, 23, '');
-        $this->add(24, 35, '');
+        $this->add(24, 35, Util::formatCnab('9', 0, 12));
         $this->add(36, 36, '');
         $this->add(37, 37, '');
 
-        // Nosso Número (38-57) - Manual: usar 38-47 e deixar 48-57 em branco
+        // Nosso Número / Identificação do título no Banco (38-57).
+        // Manual 13.3P: campo numérico de 20 posições, "serão consideradas as 10
+        // PRIMEIRAS posições". Logo o nosso número vai em 38-47 e o restante
+        // (48-57) é zero (numérico não utilizado).
         $this->add(38, 47, Util::formatCnab('9', $boleto->getNossoNumero(), 10));
-        $this->add(48, 57, '');
+        $this->add(48, 57, Util::formatCnab('9', 0, 10));
 
         // Características da cobrança (58-62)
-        $this->add(58, 58, $this->getCarteira());
-        $this->add(59, 59, '1'); // C007 = Com Cadastramento
-        $this->add(60, 60, '1'); // C008 = Tradicional
-        $this->add(61, 61, $this->getEmissaoBoleto()); // C009 = Quem emite
-        $this->add(62, 62, $this->getDistribuicaoBoleto()); // C010 = Quem distribui
+        $this->add(58, 58, Util::formatCnab('X', $this->getCarteira(), 1)); // Carteira
+        $this->add(59, 59, '1');                                            // Com cadastramento
+        $this->add(60, 60, '');                                             // Tipo de documento - não considerado
+        $this->add(61, 61, '2');                                            // Emissão: cliente emite o bloqueto
+        $this->add(62, 62, '');                                             // Distribuição - não considerado
 
-        // Número do documento (63-77) - Banrisul usa 13 chars + 2 brancos
+        // Seu Número (63-75, 13 posições) - alfanumérico obrigatório. Manual 19.3P: "serão consideradas as 13 primeiras posições"; deixar as posições 76-77 em branco.
         $this->add(63, 75, Util::formatCnab('X', $boleto->getNumeroDocumento(), 13));
         $this->add(76, 77, '');
 
+        // Vencimento (78-85) e valor do título (86-100)
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
-        // Valor do título (86-100)
-        // Manual: moeda 02 (dólar) usa 4 casas decimais; demais, 2 casas.
-        $dec = $moeda === '02' ? 4 : 2;
-        $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, $dec));
+        $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, $decValor));
 
-        // Agência cobradora (101-106) - Brancos*/zeros
-        $this->add(101, 105, '00000');
+        // Agência cobradora (101-106) - não considerado
+        $this->add(101, 105, Util::formatCnab('9', 0, 5));
         $this->add(106, 106, '');
 
-        // Espécie do título (107-108) é alfanumérica no Banrisul (ex.: AA, AB, AC, AD)
+        // Espécie do título (107-108) - alfanumérico (ex.: 02, 04, 07, 12, AA, AD)
         $this->add(107, 108, Util::formatCnab('X', $boleto->getEspecieDocCodigo(99, 240), 2));
+        // Aceite (109)
         $this->add(109, 109, Util::formatCnab('A', $boleto->getAceite(), 1));
+        // Data de emissão do título (110-117)
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));
 
-        // Juros de mora (118-141) - C018, C019, C020
-        $this->preencheJuros($boleto, $dec);
+        // Juros de mora (118-141)
+        $this->preencheJuros($boleto);
 
-        // Desconto 1 (142-165) - C021, C022, C023
-        $this->preencheDesconto($boleto);
+        // Desconto 1 (142-165)
+        $this->preencheDescontoSegmentoP($boleto);
 
-        // IOF e abatimento (166-195)
+        // Valor do IOF (166-180) - não calculado pelo sistema. Campo numérico não utilizado = zeros (manual 2.1-3), nunca espaços.
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
+        // Valor do abatimento (181-195)
         $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
 
         // Identificação do título na empresa (196-220)
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
 
-        // Protesto / Negativação (221-223) - C026/C027
+        // Protesto (221-223)
         $this->preencheProtesto($boleto);
-
-        // Baixa / Devolução (224-227) - C028/C029
+        // Baixa/Devolução (224-227)
         $this->preencheBaixa($boleto);
 
-        // Código da moeda (228-229) - G065. Default 09 = Real.
-        // Manual: códigos numéricos devem ocupar 2 posições (ex.: 09). Se vier "9",
-        // precisa virar "09" para não gerar "9 " (com espaço) e rejeitar o arquivo.
-        if (ctype_digit($moeda) && strlen($moeda) === 1) {
-            $moeda = '0' . $moeda;
-        }
+        // Código da moeda (228-229)
         $this->add(228, 229, Util::formatCnab('X', $moeda, 2));
 
-        // Número do contrato (230-239) - manual: contrato da operação de crédito
+        // Número do contrato da operação de crédito (230-239)
         $this->add(230, 239, Util::formatCnab('9', 0, 10));
 
         // CNAB final (240) - branco
@@ -408,84 +492,62 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
-     * Identificação da emissão do boleto (campo C009 do manual).
-     * Carteira de desconto: obrigatório '1' (Banco emite).
-     *
-     * @return string
-     */
-    protected function getEmissaoBoleto()
-    {
-        return (string) $this->getCarteira() === '4' ? '1' : '2';
-    }
-
-    /**
-     * Identificação da distribuição do boleto (campo C010 do manual).
-     * Carteira de desconto: obrigatório '1' (Banco distribui).
-     *
-     * @return string
-     */
-    protected function getDistribuicaoBoleto()
-    {
-        return (string) $this->getCarteira() === '4' ? '1' : '2';
-    }
-
-    /**
-     * Preenche juros conforme regras do manual (campos C018, C019, C020).
+     * Juros de mora (campos 27/28/29.3P do manual).
      *
      * @param BoletoContract $boleto
      * @throws ValidationException
      */
-    protected function preencheJuros(BoletoContract $boleto, $decValorTitulo = 2)
+    protected function preencheJuros(BoletoContract $boleto)
     {
-        // Carteira de desconto: obrigatoriamente isento (manual C018)
-        if ((string) $this->getCarteira() === '4' || $boleto->getJuros() <= 0) {
-            $this->add(118, 118, self::JUROS_ISENTO);
+        // Carteiras R e S: sem instrução de juros no Segmento P (a taxa vai no Segmento R). Campos numéricos = zeros (manual 2.1-3), nunca espaços.
+        if ($this->isCarteiraEletronica()) {
+            $this->add(118, 118, '0');
             $this->add(119, 126, '00000000');
             $this->add(127, 141, Util::formatCnab('9', 0, 15, 2));
 
             return;
         }
 
-        // Manual:
-        // - Cód. 1 = valor ao dia; cód. 2 = taxa mensal
-        // - Se data não informada, assume vencimento
-        $diasApos = max(0, (int) $boleto->getJurosApos());
-        $dataJuros = $boleto->getDataVencimento()->copy()->addDays($diasApos);
+        // Sem juros: código 0 (o código 3 é "Reservado" neste leiaute).
+        if ($boleto->getJuros() <= 0) {
+            $this->add(118, 118, '0');
+            $this->add(119, 126, '00000000');
+            $this->add(127, 141, Util::formatCnab('9', 0, 15, 2));
 
-        $moeda = (string) $boleto->getMoeda();
+            return;
+        }
+
+        // Manual 28.3P (Data Juros Mora): não enviamos data — o banco aplica os juros automaticamente após o vencimento quando o código 27.3P é 1 ou 2. Campo numérico de data sem valor = zeros (00000000), nunca espaços (manual 2.1-3). Enviar data explícita causava rejeição motivo 79.
+        $moeda = $this->getCodigoMoeda($boleto);
         if ($moeda === '02') {
-            // Para moeda 02 o manual restringe o código a "1" (valor ao dia).
-            $this->add(118, 118, self::JUROS_VALOR_DIA);
-            $this->add(119, 126, $dataJuros->format('dmY'));
-
-            // Converte taxa mensal (%) em valor/dia (aproximação 30 dias), para manter o contrato
-            // do SDK (getJuros() retorna percentual).
+            // Manual 27.3P: para moeda 02 o código só pode ser 1 (valor ao dia). getJuros() devolve percentual; convertemos para valor/dia (base 30).
             $valorDia = ((float) $boleto->getValor()) * (min((float) $boleto->getJuros(), 99.99) / 100) / 30;
+            $this->add(118, 118, self::JUROS_VALOR_DIA);
+            $this->add(119, 126, '00000000');
             $this->add(127, 141, Util::formatCnab('9', $valorDia, 15, 2));
 
             return;
         }
 
         $this->add(118, 118, self::JUROS_TAXA_MENSAL);
-        $this->add(119, 126, $dataJuros->format('dmY'));
-        $juros = min((float) $boleto->getJuros(), 99.99);
-        $this->add(127, 141, Util::formatCnab('9', $juros, 15, 2));
+        $this->add(119, 126, '00000000');
+        $this->add(127, 141, Util::formatCnab('9', min((float) $boleto->getJuros(), 99.99), 15, 2));
     }
 
     /**
-     * Preenche desconto 1 conforme regras do manual (campos C021, C022, C023).
+     * Desconto 1 (campos 30/31/32.3P do manual).
      *
-     * Para a carteira 4 (Cobrança Descontada) o manual obriga zerar todos os
-     * campos de desconto, independentemente do que foi configurado no boleto.
-     * Nas demais carteiras delega à implementação padrão CNAB 240, que
-     * aplica o mapa $tiposDescontoSuportados.
+     * Grava o código real do tipo de desconto (1=valor fixo, 2=percentual,
+     * 3=valor antecipação dia corrido, 5=percentual dia corrido). Percentual
+     * usa 1 casa decimal; valor usa 2 casas (manual 32.3P).
      *
      * @param BoletoContract $boleto
      * @throws ValidationException
      */
-    protected function preencheDesconto(BoletoContract $boleto)
+    protected function preencheDescontoSegmentoP(BoletoContract $boleto)
     {
-        if ((string) $this->getCarteira() === '4') {
+        // Carteiras R e S: sem desconto no Segmento P. Campos numéricos = zeros (manual 2.1-3), nunca espaços.
+        if ($this->isCarteiraEletronica()) {
             $this->add(142, 142, '0');
             $this->add(143, 150, '00000000');
             $this->add(151, 165, Util::formatCnab('9', 0, 15, 2));
@@ -493,19 +555,41 @@ class Banrisul extends AbstractRemessa implements RemessaContract
             return;
         }
 
-        $this->preencheDescontoSegmentoP($boleto);
+        $codigo = $this->resolveCodigoDesconto($boleto);
+        $valor = $this->resolveValorDesconto($boleto);
+
+        if ($codigo === BoletoContract::TIPO_DESCONTO_NENHUM || $valor <= 0) {
+            $this->add(142, 142, '0');
+            $this->add(143, 150, '00000000');
+            $this->add(151, 165, Util::formatCnab('9', 0, 15, 2));
+
+            return;
+        }
+
+        // Manual 31.3P: para os códigos 1 e 2, se a data não for informada,
+        // assume a data do vencimento.
+        $dataDesconto = $boleto->getDataDesconto()
+            ? $boleto->getDataDesconto()->format('dmY')
+            : $boleto->getDataVencimento()->format('dmY');
+
+        // Manual 32.3P: percentual = 1 casa decimal; valor = 2 casas decimais.
+        $dec = $this->isDescontoPercentual($boleto) ? 1 : 2;
+
+        $this->add(142, 142, $codigo);
+        $this->add(143, 150, $dataDesconto);
+        $this->add(151, 165, Util::formatCnab('9', $valor, 15, $dec));
     }
 
     /**
-     * Preenche protesto/negativação (campos C026/C027 do manual).
+     * Protesto (campos 37/38.3P do manual).
      *
      * @param BoletoContract $boleto
      * @throws ValidationException
      */
     protected function preencheProtesto(BoletoContract $boleto)
     {
-        // Carteira de desconto: campos zerados (manual C026/C027).
-        if ((string) $this->getCarteira() === '4') {
+        // Carteiras R e S: sem instrução de protesto. Código 0 (= aceito pelo banco, retorno 37) e prazo zerado; campos numéricos = zeros (manual 2.1-3).
+        if ($this->isCarteiraEletronica()) {
             $this->add(221, 221, '0');
             $this->add(222, 223, '00');
 
@@ -513,8 +597,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         }
 
         $dias = (int) $boleto->getDiasProtesto();
-        // Manual: prazo válido entre 3 e 99 dias.
         if ($dias > 0) {
+            // Manual 38.3P: se o código for 1, o número de dias deve ser >= 03.
             $dias = max(3, min(99, $dias));
             $this->add(221, 221, self::PROTESTO_DIAS_CORRIDOS);
             $this->add(222, 223, Util::formatCnab('9', $dias, 2));
@@ -527,24 +611,17 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
-     * Preenche baixa/devolução (campos C028/C029 do manual).
+     * Baixa/Devolução (campos 39.3P do manual).
      *
      * @param BoletoContract $boleto
      * @throws ValidationException
      */
     protected function preencheBaixa(BoletoContract $boleto)
     {
-        // Carteira de desconto: campos zerados.
-        if ((string) $this->getCarteira() === '4') {
-            $this->add(224, 224, '0');
-            $this->add(225, 227, '000');
-
-            return;
-        }
-
         $dias = (int) $boleto->getDiasBaixaAutomatica();
         if ($dias > 0) {
             $this->add(224, 224, self::BAIXA_DEVOLVER);
+            // Manual: "serão consideradas as duas últimas casas".
             $this->add(225, 227, Util::formatCnab('9', min(99, $dias), 3));
 
             return;
@@ -555,21 +632,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
-     * Manual seção 2.3, item 4: em campos alfanuméricos não utilizar
-     * acentuação gráfica, pontuação, parênteses, tabulações ou caracteres
-     * especiais — podem rejeitar a remessa. Substitui por espaço para
-     * preservar separação entre palavras (ex.: "AV.DESEMBARGADOR" → "AV DESEMBARGADOR").
+     * Segmento Q (registro 3, obrigatório) - manual 3.4.
      *
-     * @param string|null $value
-     *
-     * @return string
-     */
-    protected function sanitizeAlfa($value)
-    {
-        return preg_replace('/[^A-Za-z0-9 \-]/', ' ', (string) $value);
-    }
-
-    /**
      * @param BoletoContract $boleto
      *
      * @return $this
@@ -596,41 +660,39 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(34, 73, Util::formatCnab('X', $this->sanitizeAlfa($pagador->getNome()), 40));
         $this->add(74, 113, Util::formatCnab('X', $this->sanitizeAlfa($pagador->getEndereco()), 40));
         $this->add(114, 128, Util::formatCnab('X', $this->sanitizeAlfa($pagador->getBairro()), 15));
-        $this->add(129, 133, Util::formatCnab('9', Util::onlyNumbers($pagador->getCep()), 5));
-        $this->add(134, 136, Util::formatCnab('9', Util::onlyNumbers(substr($pagador->getCep(), 6, 9)), 3));
+
+        $cep = Util::onlyNumbers($pagador->getCep());
+        $this->add(129, 133, Util::formatCnab('9', substr($cep, 0, 5), 5));   // CEP
+        $this->add(134, 136, Util::formatCnab('9', substr($cep, 5, 3), 3));   // Sufixo do CEP
         $this->add(137, 151, Util::formatCnab('X', $this->sanitizeAlfa($pagador->getCidade()), 15));
         $this->add(152, 153, Util::formatCnab('X', $pagador->getUf(), 2));
 
-        // Sacador / Avalista (154-209)
-        // Manual (3.4): para títulos de terceiros (espécie AD) o preenchimento do nome
-        // do sacador/avalista (170-209) é obrigatório, bem como a inclusão do segmento Y.
+        // Sacador / Avalista (154-209). Para títulos de terceiros (AD) o nome é
+        // obrigatório, editado com um espaço em branco à esquerda (manual 3.4).
         if ($especie === 'AD' && $boleto->getSacadorAvalista()) {
             $sacador = $boleto->getSacadorAvalista();
             $this->add(154, 154, $this->getTipoInscricao($sacador->getDocumento()));
             $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($sacador->getDocumento()), 15));
-
-            $nome = $this->sanitizeAlfa($sacador->getNome());
-            $nomeEditado = ' ' . ltrim($nome);
+            $nomeEditado = ' ' . ltrim($this->sanitizeAlfa($sacador->getNome()));
             $this->add(170, 209, Util::formatCnab('X', $nomeEditado, 40));
         } else {
             $this->add(154, 154, '0');
-            $this->add(155, 169, '000000000000000');
+            $this->add(155, 169, Util::formatCnab('9', 0, 15));
             $this->add(170, 209, '');
         }
 
-        // Banco correspondente (210-232) - Brancos*
-        $this->add(210, 212, '000');
+        // Banco correspondente (210-232) - não considerado
+        $this->add(210, 212, Util::formatCnab('9', 0, 3));
         $this->add(213, 232, '');
 
-        // CNAB final (233-240) - Brancos*
+        // CNAB final (233-240) - BRANCOS
         $this->add(233, 240, '');
 
         return $this;
     }
 
     /**
-     * Segmento R - Multa e mensagens 3/4. Não permitido para carteira de
-     * desconto (manual seção 3.6).
+     * Segmento R (registro 3, opcional) - manual 3.5. Multa e mensagens 3/4.
      *
      * @param BoletoContract $boleto
      *
@@ -650,63 +712,60 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(15, 15, '');
         $this->add(16, 17, $movimento);
 
-        // Desconto 2 (18-41) - Não utilizado
+        // Desconto 2 (18-41) - não utilizado
         $this->add(18, 18, '0');
         $this->add(19, 26, '00000000');
         $this->add(27, 41, Util::formatCnab('9', 0, 15, 2));
 
-        // Desconto 3 (42-65) - Manual: campos não validados pelo Banrisul
+        // Desconto 3 (42-65) - não utilizado
         $this->add(42, 42, '0');
         $this->add(43, 50, '00000000');
         $this->add(51, 65, Util::formatCnab('9', 0, 15, 2));
 
-        // Multa (66-89) - G073/G074/G075
+        // Multa (66-89) - manual 14/15/16.3R
         if ($boleto->getMulta() > 0) {
             $dataMulta = $boleto->getDataVencimento()
                 ->copy()
                 ->addDays(max(1, (int) $boleto->getMultaApos()));
+            // Manual 16.3R: percentual = 1 casa decimal; carteiras P/Q/R/S = 3 casas.
+            $dec = in_array((string) $this->getCarteira(), ['P', 'Q', 'R', 'S'], true) ? 3 : 1;
             $this->add(66, 66, self::MULTA_PERCENTUAL);
-            $this->add(67, 74, $dataMulta->format('dmY'));
-            $this->add(75, 89, Util::formatCnab('9', $boleto->getMulta(), 15, 2));
+            // Manual 15.3R: data da multa obrigatória, exceto carteira F (em branco).
+            $this->add(67, 74, (string) $this->getCarteira() === 'F' ? '' : $dataMulta->format('dmY'));
+            $this->add(75, 89, Util::formatCnab('9', $boleto->getMulta(), 15, $dec));
         } else {
             $this->add(66, 66, '0');
             $this->add(67, 74, '00000000');
             $this->add(75, 89, Util::formatCnab('9', 0, 15, 2));
         }
 
-        // Informação ao pagador (90-99) - Brancos*
+        // Informação ao Pagador (90-99) - não considerado
         $this->add(90, 99, '');
 
-        // Mensagens 3 e 4 (100-179) - até 2 instruções livres
-        $instrucoes = $boleto->getInstrucoes() ?: [];
-        $this->add(100, 139, Util::formatCnab('X', $instrucoes[0] ?? '', 40));
-        $this->add(140, 179, Util::formatCnab('X', $instrucoes[1] ?? '', 40));
+        // Mensagens 3 e 4 (100-179) - prevalecem sobre as mensagens 1 e 2
+        $instrucoes = array_values(array_filter((array) $boleto->getInstrucoes(), function ($i) {
+            return trim((string) $i) !== '';
+        }));
+        $this->add(100, 139, Util::formatCnab('X', $this->sanitizeAlfa($instrucoes[0] ?? ''), 40));
+        $this->add(140, 179, Util::formatCnab('X', $this->sanitizeAlfa($instrucoes[1] ?? ''), 40));
 
-        // CNAB (180-199) - Brancos*
-        $this->add(180, 199, '');
+        // Dados para débito em conta corrente (180-199) - não considerado (numérico)
+        $this->add(180, 182, Util::formatCnab('9', 0, 3));   // Banco
+        $this->add(183, 186, Util::formatCnab('9', 0, 4));   // Agência
+        $this->add(187, 199, Util::formatCnab('9', 0, 13));  // Conta/DV
 
-        // Cód ocorrência do pagador (200-207) - não considerado em remessa
-        $this->add(200, 207, '00000000');
+        // Código de ocorrência do Pagador (200-207) - não considerado (numérico)
+        $this->add(200, 207, Util::formatCnab('9', 0, 8));
 
-        // Dados de débito automático (208-230) - Não considerado
-        $this->add(208, 210, '000');
-        $this->add(211, 215, '00000');
-        $this->add(216, 216, '');
-        $this->add(217, 228, Util::formatCnab('9', 0, 12));
-        $this->add(229, 229, '');
-        $this->add(230, 230, '');
-
-        // Aviso para débito automático (231) - não considerado
-        $this->add(231, 231, '0');
-
-        // CNAB final (232-240)
-        $this->add(232, 240, '');
+        // CNAB final (208-240) - BRANCOS
+        $this->add(208, 240, '');
 
         return $this;
     }
 
     /**
-     * Segmento Y-01 - Sacador/Avalista (manual seção 3.7).
+     * Segmento Y-01 - Sacador/Avalista (manual 3.7). Obrigatório apenas para
+     * títulos de terceiros.
      *
      * @param BoletoContract $boleto
      *
@@ -724,10 +783,9 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'Y');
         $this->add(15, 15, '');
-        // Manual (3.7): movimento do segmento Y-01 é 01 (entrada de títulos)
+        // Manual 07.3Y: código de movimento remessa = 01.
         $this->add(16, 17, self::OCORRENCIA_REMESSA);
-
-        // Manual (3.7): Identificação registro opcional = 03
+        // Manual 08.3Y: identificação de registro opcional = 03.
         $this->add(18, 19, '03');
 
         $this->add(20, 20, $this->getTipoInscricao($sacador->getDocumento()));
@@ -736,127 +794,21 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(76, 115, Util::formatCnab('X', $this->sanitizeAlfa($sacador->getEndereco()), 40));
         $this->add(116, 130, Util::formatCnab('X', $this->sanitizeAlfa($sacador->getBairro()), 15));
 
-        // Manual (3.7): CEP (5 num) + Sufixo CEP (3 num) - separados.
         $cep = Util::onlyNumbers($sacador->getCep());
         $this->add(131, 135, Util::formatCnab('9', substr($cep, 0, 5), 5));
         $this->add(136, 138, Util::formatCnab('9', substr($cep, 5, 3), 3));
-
         $this->add(139, 153, Util::formatCnab('X', $this->sanitizeAlfa($sacador->getCidade()), 15));
         $this->add(154, 155, Util::formatCnab('X', $sacador->getUf(), 2));
 
-        // CNAB final (156-240) - Brancos
+        // CNAB final (156-240) - BRANCOS
         $this->add(156, 240, '');
 
         return $this;
     }
 
     /**
-     * @return $this
-     * @throws ValidationException
-     */
-    protected function header()
-    {
-        $this->iniciaHeader();
-
-        $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0000');
-        $this->add(8, 8, '0');
-        // CNAB (9-17) - Brancos*
-        $this->add(9, 17, '');
-
-        // Empresa (18-72)
-        $this->add(18, 18, $this->getTipoInscricao($this->getBeneficiario()->getDocumento()));
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
-        // Manual G007: informar à esquerda e deixar espaços em branco à direita.
-        $this->add(33, 52, $this->getConvenioCnab20());
-        // Conta corrente (53-72) - Banrisul: campo "Brancos*" (não considerado),
-        // mas a regra geral 2.3 item 1 do manual exige zeros para Num não utilizado;
-        // validadores estritos rejeitam Num preenchido com espaços.
-        $this->add(53, 57, Util::formatCnab('9', 0, 5));
-        $this->add(58, 58, ''); // DV agência (Alfa)
-        $this->add(59, 70, Util::formatCnab('9', 0, 12));
-        // Manual 240 posições: DV da conta é numérico (1).
-        // Como o bloco é "não considerado" pelo banco, mantemos 0 para respeitar tipo numérico.
-        $this->add(71, 71, '0');
-        $this->add(72, 72, ''); // DV ag/conta (Alfa)
-
-        // Nome do beneficiário (73-102) e nome do banco (103-132)
-        $this->add(73, 102, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
-        $this->add(103, 132, Util::formatCnab('X', 'BANRISUL', 30));
-
-        // CNAB (133-142) - Brancos*
-        $this->add(133, 142, '');
-
-        // Arquivo (143-171)
-        $this->add(143, 143, '1'); // 1 = Remessa (G015)
-        $this->add(144, 151, $this->getDataRemessa('dmY'));
-        $this->add(152, 157, date('His'));
-        $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
-        $this->add(164, 166, '040'); // Layout do arquivo - manual 240 posições
-        $this->add(167, 171, '00000'); // Densidade (G020) - zeros/brancos
-
-        // Reservados (172-191)
-        // Manual: 180-181 = "BE" (uso reservado do Banco – remessa).
-        $this->add(172, 179, '');
-        $this->add(180, 181, 'BE');
-        $this->add(182, 191, '');
-        $this->add(192, 211, '');
-        $this->add(212, 240, '');
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     * @throws ValidationException
-     */
-    protected function headerLote()
-    {
-        $this->iniciaHeaderLote();
-
-        $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
-        $this->add(8, 8, '1');
-
-        // Serviço (9-16) - manual 240 posições
-        $this->add(9, 9, 'R'); // G028 = Remessa
-        $this->add(10, 11, '01'); // G025 = Cobrança
-        $this->add(12, 13, '00'); // Forma de lançamento (manual: 00)
-        $this->add(14, 16, '020'); // Layout do lote (manual)
-        $this->add(17, 17, '');
-
-        // Empresa (18-73)
-        $this->add(18, 18, $this->getTipoInscricao($this->getBeneficiario()->getDocumento()));
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
-        // Manual G007: informar à esquerda e deixar espaços em branco à direita.
-        $this->add(34, 53, $this->getConvenioCnab20());
-        // Conta corrente (54-73) - Banrisul: campo "Brancos*" (não considerado),
-        // mas Num não utilizado exige zeros pela regra geral 2.3 item 1 do manual.
-        $this->add(54, 58, Util::formatCnab('9', 0, 5));
-        $this->add(59, 59, ''); // DV agência (Alfa)
-        $this->add(60, 71, Util::formatCnab('9', 0, 12));
-        $this->add(72, 72, ''); // DV conta (Alfa)
-        $this->add(73, 73, ''); // DV ag/conta (Alfa)
-
-        $this->add(74, 103, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
-
-        // Mensagens 1 e 2 (104-183) - opcionais
-        $this->add(104, 143, '');
-        $this->add(144, 183, '');
-
-        // Controle cobrança (184-207)
-        $this->add(184, 191, Util::formatCnab('9', $this->getIdremessa(), 8));
-        $this->add(192, 199, $this->getDataRemessa('dmY'));
-        // Data do crédito (200-207) - Manual: Brancos* na remessa.
-        $this->add(200, 207, '');
-
-        // CNAB final (208-240) - Brancos*
-        $this->add(208, 240, '');
-
-        return $this;
-    }
-
-    /**
+     * Trailler de Lote (registro 5) - manual 3.10.
+     *
      * @return $this
      * @throws ValidationException
      */
@@ -871,37 +823,36 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(8, 8, '5');
         $this->add(9, 17, '');
 
-        // Quantidade total de registros do lote (header + detalhes + trailer)
+        // Quantidade de registros do lote (header de lote + detalhes + trailler).
         $this->add(18, 23, Util::formatCnab('9', $this->getCountDetalhes() + 2, 6));
 
         // Cobrança Simples (24-46)
         $this->add(24, 29, Util::formatCnab('9', $totais['simples']['qtd'], 6));
         $this->add(30, 46, Util::formatCnab('9', $totais['simples']['valor'], 17, 2));
-
         // Cobrança Vinculada (47-69)
         $this->add(47, 52, Util::formatCnab('9', $totais['vinculada']['qtd'], 6));
         $this->add(53, 69, Util::formatCnab('9', $totais['vinculada']['valor'], 17, 2));
-
         // Cobrança Caucionada (70-92)
         $this->add(70, 75, Util::formatCnab('9', $totais['caucionada']['qtd'], 6));
         $this->add(76, 92, Util::formatCnab('9', $totais['caucionada']['valor'], 17, 2));
-
         // Cobrança Descontada (93-115)
         $this->add(93, 98, Util::formatCnab('9', $totais['descontada']['qtd'], 6));
         $this->add(99, 115, Util::formatCnab('9', $totais['descontada']['valor'], 17, 2));
 
         // Número do aviso de lançamento (116-123) - não considerado
         $this->add(116, 123, '');
-
-        // CNAB final (124-240) - Brancos*
+        // CNAB final (124-240) - BRANCOS
         $this->add(124, 240, '');
 
         return $this;
     }
 
     /**
-     * Totaliza títulos por carteira (cobrança simples / vinculada / caucionada
-     * / descontada) para preencher o trailer do lote conforme manual (3.14).
+     * Totaliza títulos por modalidade de cobrança para o trailler do lote.
+     *
+     * Carteiras 1 = simples; 2 = vinculada; 3 = caucionada; R/S = descontada
+     * (desconto/vendor eletrônico). Demais carteiras são contabilizadas como
+     * simples por padrão.
      *
      * @return array
      */
@@ -911,7 +862,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
             '1' => 'simples',
             '2' => 'vinculada',
             '3' => 'caucionada',
-            '4' => 'descontada',
+            'R' => 'descontada',
+            'S' => 'descontada',
         ];
 
         $tipo = $mapa[(string) $this->getCarteira()] ?? 'simples';
@@ -932,6 +884,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     }
 
     /**
+     * Trailler de Arquivo (registro 9) - manual 3.11.
+     *
      * @return $this
      * @throws ValidationException
      */
@@ -943,13 +897,13 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '9999');
         $this->add(8, 8, '9');
         $this->add(9, 17, '');
-        // Quantidade de lotes do arquivo (G049)
+        // Quantidade de lotes do arquivo (registros tipo 1)
         $this->add(18, 23, Util::formatCnab('9', 1, 6));
-        // Quantidade de registros do arquivo (G056)
+        // Quantidade de registros do arquivo (tipos 0+1+3+5+9)
         $this->add(24, 29, Util::formatCnab('9', $this->getCount(), 6));
-        // Quantidade de contas para conciliação (G037) - exclusivo conciliação
+        // Quantidade de contas para conciliação - não considerado
         $this->add(30, 35, Util::formatCnab('9', 0, 6));
-        // CNAB final (36-240) - Brancos*
+        // CNAB final (36-240) - BRANCOS
         $this->add(36, 240, '');
 
         return $this;

--- a/tests/Remessa/RemessaCnab240Test.php
+++ b/tests/Remessa/RemessaCnab240Test.php
@@ -137,4 +137,144 @@ class RemessaCnab240Test extends TestCase
         $this->assertFileExists($file);
         $this->assertEquals($file, $file2);
     }
+
+    /**
+     * Banrisul CNAB 240 - cobrança. Valida posições conforme o manual oficial
+     * "Cobrança Banrisul - Leiaute CNAB 240 Posições" (manuais/BANRISUL/240_posicoes.pdf).
+     */
+    public function testRemessaBanrisulCnab240()
+    {
+        $beneficiario = new Pessoa([
+            'nome'      => 'EMPRESA BENEFICIARIA EXEMPLO LTDA',
+            'endereco'  => 'AV DESEMBARGADOR, 123',
+            'cep'       => '90230-090',
+            'uf'        => 'RS',
+            'cidade'    => 'PORTO ALEGRE',
+            'documento' => '12.345.678/0001-90',
+        ]);
+
+        $boleto = new Boleto\Banrisul([
+            'dataVencimento'  => new \Carbon\Carbon('2026-07-15'),
+            'dataDocumento'   => new \Carbon\Carbon('2026-06-11'),
+            'valor'           => 1234.56,
+            'multa'           => 2.00,
+            'juros'           => 1.00,
+            'numero'          => 25,
+            'numeroDocumento' => 'DOC12345',
+            'numeroControle'  => 'CTRL-001',
+            'pagador'         => self::$pagador,
+            'beneficiario'    => $beneficiario,
+            'agencia'         => 100,
+            'conta'           => 6677,
+            'carteira'        => '1',
+            'codigoCliente'   => '0001234567890',
+            'diasProtesto'    => 5,
+            'aceite'          => 'N',
+            'especieDoc'      => 'DM',
+            'instrucoes'      => ['NAO RECEBER APOS 30 DIAS', 'JUROS DE 1 PORCENTO AO MES'],
+        ]);
+
+        $remessa = new Remessa\Banrisul([
+            'idremessa'     => 1,
+            'agencia'       => 100,
+            'conta'         => 6677,
+            'contaDv'       => 5,
+            'carteira'      => '1',
+            'codigoCliente' => '0001234567890',
+            'beneficiario'  => $beneficiario,
+        ]);
+        $remessa->setDataRemessa(new \Carbon\Carbon('2026-06-11'));
+        $remessa->addBoleto($boleto);
+
+        $content = $remessa->gerar();
+        $lines = preg_split('/\r\n/', rtrim($content, "\r\n"));
+
+        $field = function ($line, $i, $f) {
+            return substr($line, $i - 1, $f - $i + 1);
+        };
+
+        // Estrutura: header arquivo, header lote, P, Q, R, trailer lote, trailer arquivo.
+        $this->assertCount(7, $lines);
+        foreach ($lines as $n => $line) {
+            $this->assertEquals(240, strlen($line), "Linha " . ($n + 1) . " deve ter 240 bytes");
+        }
+
+        [$header, $headerLote, $p, $q, $r, $trailerLote, $trailerArquivo] = $lines;
+
+        // --- Header de Arquivo (3.1) ---
+        $this->assertEquals('041', $field($header, 1, 3));
+        $this->assertEquals('0000', $field($header, 4, 7));
+        $this->assertEquals('0', $field($header, 8, 8));
+        $this->assertEquals('2', $field($header, 18, 18)); // CNPJ
+        $this->assertEquals('00012345678900000000', $field($header, 33, 52)); // convênio 13+7
+        $this->assertEquals('00100', $field($header, 53, 57)); // agência (0AAAA) - considerada no header de arquivo
+        $this->assertEquals(' ', $field($header, 58, 58)); // DV agência - branco
+        $this->assertEquals('000000006677', $field($header, 59, 70)); // conta
+        $this->assertEquals('5', $field($header, 71, 71)); // DV conta - numérico
+        $this->assertEquals(' ', $field($header, 72, 72)); // DV ag/conta - branco
+        $this->assertEquals('1', $field($header, 143, 143)); // remessa
+        $this->assertEquals('11062026', $field($header, 144, 151));
+        $this->assertEquals('040', $field($header, 164, 166)); // layout arquivo
+        $this->assertEquals('00000', $field($header, 167, 171));
+        $this->assertEquals('BE', $field($header, 180, 181));
+
+        // --- Header de Lote (3.2) ---
+        $this->assertEquals('1', $field($headerLote, 8, 8));
+        $this->assertEquals('R', $field($headerLote, 9, 9));
+        $this->assertEquals('01', $field($headerLote, 10, 11));
+        $this->assertEquals('00', $field($headerLote, 12, 13));
+        $this->assertEquals('020', $field($headerLote, 14, 16)); // layout lote
+        $this->assertEquals('00012345678900000000', $field($headerLote, 34, 53));
+
+        // --- Segmento P (3.3) ---
+        $this->assertEquals('P', $field($p, 14, 14));
+        $this->assertEquals('01', $field($p, 16, 17)); // movimento: entrada
+        $this->assertEquals('0000002577', $field($p, 38, 47)); // nosso número (10 primeiras posições)
+        $this->assertEquals('0000000000', $field($p, 48, 57)); // restante numérico = zeros (não brancos)
+        $this->assertEquals('1', $field($p, 58, 58)); // carteira
+        $this->assertEquals('1', $field($p, 59, 59)); // com cadastramento
+        $this->assertEquals('2', $field($p, 61, 61)); // cliente emite
+        $this->assertEquals('DOC12345       ', $field($p, 63, 77)); // nº documento (15, alfa)
+        $this->assertEquals('15072026', $field($p, 78, 85)); // vencimento
+        $this->assertEquals('000000000123456', $field($p, 86, 100)); // valor (15,2)
+        $this->assertEquals('02', $field($p, 107, 108)); // espécie DM -> 02
+        $this->assertEquals('N', $field($p, 109, 109)); // aceite
+        $this->assertEquals('2', $field($p, 118, 118)); // juros: taxa mensal
+        $this->assertEquals('15072026', $field($p, 119, 126)); // data juros = vencimento (literal ao manual)
+        $this->assertEquals('000000000000100', $field($p, 127, 141)); // 1,00
+        $this->assertEquals('0', $field($p, 142, 142)); // sem desconto
+        $this->assertEquals('105', $field($p, 221, 223)); // protestar, 05 dias
+        $this->assertEquals('0000', $field($p, 224, 227)); // sem baixa
+        $this->assertEquals('09', $field($p, 228, 229)); // moeda Real
+        $this->assertEquals(' ', $field($p, 240, 240));
+
+        // --- Segmento Q (3.4) ---
+        $this->assertEquals('Q', $field($q, 14, 14));
+        $this->assertEquals('1', $field($q, 18, 18)); // CPF
+        $this->assertEquals('99999', $field($q, 129, 133)); // CEP (pagador 99999-999)
+        $this->assertEquals('999', $field($q, 134, 136)); // sufixo CEP
+        $this->assertEquals('UF', $field($q, 152, 153));
+        $this->assertEquals('0', $field($q, 154, 154)); // sem sacador
+
+        // --- Segmento R (3.5) ---
+        $this->assertEquals('R', $field($r, 14, 14));
+        $this->assertEquals('3', $field($r, 66, 66)); // multa percentual
+        $this->assertEquals('16072026', $field($r, 67, 74)); // venc + 1 dia
+        $this->assertEquals('000000000000020', $field($r, 75, 89)); // 2,0% (1 casa decimal)
+        $this->assertEquals('NAO RECEBER APOS 30 DIAS                ', $field($r, 100, 139));
+        $this->assertEquals('JUROS DE 1 PORCENTO AO MES              ', $field($r, 140, 179));
+        $this->assertEquals(str_repeat(' ', 33), $field($r, 208, 240)); // cauda BRANCOS
+
+        // --- Trailler de Lote (3.10) ---
+        $this->assertEquals('5', $field($trailerLote, 8, 8));
+        $this->assertEquals('000005', $field($trailerLote, 18, 23)); // header lote + 3 detalhes + trailer
+        $this->assertEquals('000001', $field($trailerLote, 24, 29)); // 1 título simples
+        $this->assertEquals('00000000000123456', $field($trailerLote, 30, 46)); // valor simples (17,2)
+
+        // --- Trailler de Arquivo (3.11) ---
+        $this->assertEquals('9', $field($trailerArquivo, 8, 8));
+        $this->assertEquals('9999', $field($trailerArquivo, 4, 7));
+        $this->assertEquals('000001', $field($trailerArquivo, 18, 23)); // 1 lote
+        $this->assertEquals('000007', $field($trailerArquivo, 24, 29)); // 0+1+3*3... = 7 registros
+    }
 }


### PR DESCRIPTION
## ✨ Principais novidades

-   💰 **Boletos do Banrisul voltam a ser registrados** — corrigida a geração do arquivo de cobrança que estava fazendo o banco recusar boletos com juros configurado. Agora os boletos são aceitos normalmente no registro.

## 🔧 Pequenos ajustes

-   💰 Nomes de pagadores com acento (ex.: *José*, *Conceição*) deixam de ser cortados no boleto e passam a sair completos e corretos no arquivo enviado ao banco.
-   💰 Ajustados o número do documento e demais campos do boleto Banrisul ao padrão exigido pelo banco, evitando recusas no envio da cobrança.
